### PR TITLE
Plugin Organizer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginDescriptor.java
@@ -58,4 +58,6 @@ public @interface PluginDescriptor
 	boolean developerPlugin() default false;
 
 	boolean loadWhenOutdated() default false;
+
+    String type() default "";
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningConfig.java
@@ -28,9 +28,22 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
+import java.awt.*;
+
 @ConfigGroup("aoe")
 public interface AoeWarningConfig extends Config
 {
+	@ConfigItem(
+			keyName = "pluginType",
+			name = "Plugin Type",
+			description = "Sets the group of this plugin",
+			hidden = true
+	)
+	default String pluginTyoe()
+	{
+		return "PVM";
+	}
+
 	@ConfigItem(
 			keyName = "enabled",
 			name = "AoE Warnings Enabled",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/aoewarnings/AoeWarningPlugin.java
@@ -61,9 +61,10 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 @PluginDescriptor(
-	name = "<font color=\"green\">!AoE Warnings</font>",
+	name = "AoE Warnings",
 	description = "Shows the final destination for AoE Attack projectiles",
-	tags = {"bosses", "combat", "pve", "overlay"}
+	tags = {"bosses", "combat", "pve", "overlay"},
+		type = "PVM"
 )
 
 @Slf4j

--- a/runelite-client/src/main/java/net/runelite/client/plugins/clanmanmode/ClanManModePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/clanmanmode/ClanManModePlugin.java
@@ -22,9 +22,10 @@ import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
-	name = "<font color=\"aqua\">!Clan Man Mode</font>",
+	name = "Clan Man Mode",
 	description = "Assists in clan PVP scenarios",
-	tags = {"highlight", "minimap", "overlay", "players"}
+	tags = {"highlight", "minimap", "overlay", "players"},
+		type = "PVP"
 )
 public class ClanManModePlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/ConfigPanel.java
@@ -82,6 +82,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginInstantiationException;
 import net.runelite.client.plugins.PluginManager;
+import net.runelite.client.plugins.pluginsorter.PluginSorterPlugin;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.DynamicGridLayout;
 import net.runelite.client.ui.PluginPanel;
@@ -112,7 +113,7 @@ public class ConfigPanel extends PluginPanel
 	private final ScheduledExecutorService executorService;
 	private final RuneLiteConfig runeLiteConfig;
 	private final ChatColorConfig chatColorConfig;
-	private final List<PluginListItem> pluginList = new ArrayList<>();
+	public static List<PluginListItem> pluginList = new ArrayList<>();
 
 	private final IconTextField searchBar = new IconTextField();
 	private final JPanel topPanel;
@@ -187,40 +188,123 @@ public class ConfigPanel extends PluginPanel
 
 		initializePluginList();
 		refreshPluginList();
+
 	}
 
 	private void initializePluginList()
 	{
 		final List<String> pinnedPlugins = getPinnedPluginNames();
 
-		// populate pluginList with all non-hidden plugins
+		List<PluginListItem> pvmPlugins = new ArrayList<>();
+		// populate pluginList with all PVM Plugins
 		pluginManager.getPlugins().stream()
-				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).hidden())
+				.filter(plugin -> plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("PVM"))
 				.forEach(plugin ->
 				{
 					final PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
 					final Config config = pluginManager.getPluginConfigProxy(plugin);
 					final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
 
-					final PluginListItem listItem = new PluginListItem(this, plugin, descriptor, config, configDescriptor);
+					final PluginListItem listItem = new PluginListItem(this, configManager, plugin, descriptor, config, configDescriptor);
+					System.out.println("Started "+listItem.getName());
 					listItem.setPinned(pinnedPlugins.contains(listItem.getName()));
-					pluginList.add(listItem);
+					pvmPlugins.add(listItem);
 				});
 
+		pvmPlugins.sort(Comparator.comparing(PluginListItem::getName));
+		for (PluginListItem plugin : pvmPlugins)
+			pluginList.add(plugin);
+
+		List<PluginListItem> pvpPlugins = new ArrayList<>();
+		// populate pluginList with all PVP Plugins
+		pluginManager.getPlugins().stream()
+				.filter(plugin -> plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("PVP"))
+				.forEach(plugin ->
+				{
+					final PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+					final Config config = pluginManager.getPluginConfigProxy(plugin);
+					final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
+
+					final PluginListItem listItem = new PluginListItem(this, configManager, plugin, descriptor, config, configDescriptor);
+					System.out.println("Started "+listItem.getName());
+					listItem.setPinned(pinnedPlugins.contains(listItem.getName()));
+					pvpPlugins.add(listItem);
+				});
+
+		pvpPlugins.sort(Comparator.comparing(PluginListItem::getName));
+		for (PluginListItem plugin : pvpPlugins)
+			pluginList.add(plugin);
+
+		List<PluginListItem> utilPlugins = new ArrayList<>();
+		// populate pluginList with all PVP Plugins
+		pluginManager.getPlugins().stream()
+				.filter(plugin -> plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("utility"))
+				.forEach(plugin ->
+				{
+					final PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+					final Config config = pluginManager.getPluginConfigProxy(plugin);
+					final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
+
+					final PluginListItem listItem = new PluginListItem(this, configManager, plugin, descriptor, config, configDescriptor);
+					System.out.println("Started "+listItem.getName());
+					listItem.setPinned(pinnedPlugins.contains(listItem.getName()));
+					utilPlugins.add(listItem);
+				});
+
+		utilPlugins.sort(Comparator.comparing(PluginListItem::getName));
+		for (PluginListItem plugin : utilPlugins)
+			pluginList.add(plugin);
+
+		// populate pluginList with all vanilla RL plugins
+		List<PluginListItem> vanillaPlugins = new ArrayList<>();
+		pluginManager.getPlugins().stream()
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).hidden())
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("PVM"))
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("PVP"))
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("utility"))
+				.filter(plugin -> !plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("pluginOrganizer"))
+				.forEach(plugin ->
+				{
+					final PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+					final Config config = pluginManager.getPluginConfigProxy(plugin);
+					final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
+
+					final PluginListItem listItem = new PluginListItem(this, configManager, plugin, descriptor, config, configDescriptor);
+					listItem.setPinned(pinnedPlugins.contains(listItem.getName()));
+					vanillaPlugins.add(listItem);
+				}
+				);
+
+		vanillaPlugins.sort(Comparator.comparing(PluginListItem::getName));
+		for (PluginListItem plugin : vanillaPlugins)
+			pluginList.add(plugin);
+
 		// add special entries for core client configurations
-		final PluginListItem runeLite = new PluginListItem(this, runeLiteConfig,
+		final PluginListItem runeLite = new PluginListItem(this, configManager, runeLiteConfig,
 				configManager.getConfigDescriptor(runeLiteConfig),
 				RUNELITE_PLUGIN, "RuneLite client settings", "client");
 		runeLite.setPinned(pinnedPlugins.contains(RUNELITE_PLUGIN));
 		pluginList.add(runeLite);
 
-		final PluginListItem chatColor = new PluginListItem(this, chatColorConfig,
+		final PluginListItem chatColor = new PluginListItem(this, configManager, chatColorConfig,
 				configManager.getConfigDescriptor(chatColorConfig),
 				CHAT_COLOR_PLUGIN, "Recolor chat text", "colour", "messages");
 		chatColor.setPinned(pinnedPlugins.contains(CHAT_COLOR_PLUGIN));
 		pluginList.add(chatColor);
 
-		pluginList.sort(Comparator.comparing(PluginListItem::getName));
+		// Add plugin sorter to bottom
+		pluginManager.getPlugins().stream()
+				.filter(plugin -> plugin.getClass().getAnnotation(PluginDescriptor.class).type().equals("pluginOrganizer"))
+				.forEach(plugin ->
+				{
+					final PluginDescriptor descriptor = plugin.getClass().getAnnotation(PluginDescriptor.class);
+					final Config config = pluginManager.getPluginConfigProxy(plugin);
+					final ConfigDescriptor configDescriptor = config == null ? null : configManager.getConfigDescriptor(config);
+
+					final PluginListItem listItem = new PluginListItem(this, configManager, plugin, descriptor, config, configDescriptor);
+					System.out.println("Started "+listItem.getName());
+					pluginList.add(listItem);
+				});
 	}
 
 	void refreshPluginList()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/config/PluginListItem.java
@@ -33,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.inject.Inject;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -40,16 +41,20 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigDescriptor;
+import net.runelite.client.config.ConfigItemDescriptor;
+import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.components.IconButton;
+import net.runelite.client.util.ColorUtil;
 import net.runelite.client.util.ImageUtil;
 import org.apache.commons.text.similarity.JaroWinklerDistance;
 
-class PluginListItem extends JPanel
+public class PluginListItem extends JPanel
 {
 	private static final JaroWinklerDistance DISTANCE = new JaroWinklerDistance();
+	public JLabel nameLabel;
 
 	private static final ImageIcon CONFIG_ICON;
 	private static final ImageIcon CONFIG_ICON_HOVER;
@@ -59,6 +64,7 @@ class PluginListItem extends JPanel
 	private static final ImageIcon OFF_STAR;
 
 	private final ConfigPanel configPanel;
+	public final ConfigManager configManager;
 
 	@Getter
 	@Nullable
@@ -70,7 +76,7 @@ class PluginListItem extends JPanel
 
 	@Nullable
 	@Getter(AccessLevel.PACKAGE)
-	private final ConfigDescriptor configDescriptor;
+	public final ConfigDescriptor configDescriptor;
 
 	@Getter
 	private final String name;
@@ -120,26 +126,27 @@ class PluginListItem extends JPanel
 	 * Note that {@code config} and {@code configDescriptor} can be {@code null}
 	 * if there is no configuration associated with the plugin.
 	 */
-	PluginListItem(ConfigPanel configPanel, Plugin plugin, PluginDescriptor descriptor,
+	PluginListItem(ConfigPanel configPanel, ConfigManager configManager, Plugin plugin, PluginDescriptor descriptor,
 				   @Nullable Config config, @Nullable ConfigDescriptor configDescriptor)
 	{
-		this(configPanel, plugin, config, configDescriptor,
+		this(configPanel, configManager, plugin, config, configDescriptor,
 				descriptor.name(), descriptor.description(), descriptor.tags());
 	}
 
 	/**
 	 * Creates a new {@code PluginListItem} for a core configuration.
 	 */
-	PluginListItem(ConfigPanel configPanel, Config config, ConfigDescriptor configDescriptor,
+	PluginListItem(ConfigPanel configPanel, ConfigManager configManager, Config config, ConfigDescriptor configDescriptor,
 				   String name, String description, String... tags)
 	{
-		this(configPanel, null, config, configDescriptor, name, description, tags);
+		this(configPanel, configManager, null, config, configDescriptor, name, description, tags);
 	}
 
-	private PluginListItem(ConfigPanel configPanel, @Nullable Plugin plugin, @Nullable Config config,
+	private PluginListItem(ConfigPanel configPanel, ConfigManager configManager, @Nullable Plugin plugin, @Nullable Config config,
 						   @Nullable ConfigDescriptor configDescriptor, String name, String description, String... tags)
 	{
 		this.configPanel = configPanel;
+		this.configManager = configManager;
 		this.plugin = plugin;
 		this.config = config;
 		this.configDescriptor = configDescriptor;
@@ -152,8 +159,7 @@ class PluginListItem extends JPanel
 		setLayout(new BorderLayout(3, 0));
 		setPreferredSize(new Dimension(PluginPanel.PANEL_WIDTH, 20));
 
-		JLabel nameLabel = new JLabel(name);
-		nameLabel.setForeground(Color.WHITE);
+		nameLabel = new JLabel(name);
 
 		if (!description.isEmpty())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/equipmentinspector/EquipmentInspectorPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/equipmentinspector/EquipmentInspectorPlugin.java
@@ -32,8 +32,10 @@ import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 
 @PluginDescriptor(
-		name = "<font color=\"green\">!Equipment Inspector</font>",
-		enabledByDefault = false
+		name = "Equipment Inspector",
+		description = "Inspects enemy equipment",
+		enabledByDefault = false,
+		type = "PVP"
 )
 
 @Slf4j

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcavejadhelper/FightCaveJadHelperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcavejadhelper/FightCaveJadHelperPlugin.java
@@ -15,9 +15,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-	name = "<font color=\"#4863A0\">!Fight Cave - Jad</font>",
+	name = "Fight Cave - Jad",
 	description = "Show what to pray against Jad",
 	tags = {"bosses", "combat", "minigame", "overlay", "prayer", "pve", "pvm"},
+		type = "PVM",
         enabledByDefault = false
 )
 public class FightCaveJadHelperPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/fightcavewavehelper/FightCaveWaveHelperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/fightcavewavehelper/FightCaveWaveHelperPlugin.java
@@ -45,9 +45,10 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
-	name = "<font color=\"#4863A0\">!Fight Cave - Waves</font>",
+	name = "Fight Cave - Waves",
 	description = "Displays current and upcoming wave monsters in the Fight Caves",
 	tags = {"bosses", "combat", "minigame", "overlay", "pve", "pvm", "jad", "fire", "cape", "wave"},
+		type = "PVM",
         enabledByDefault = false
 )
 public class FightCaveWaveHelperPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersPlugin.java
@@ -57,9 +57,10 @@ import net.runelite.client.util.ImageUtil;
 import org.slf4j.Logger;
 
 @PluginDescriptor(
-	name = "<font color=\"aqua\">!Freeze Timers</font>",
+	name = "Freeze Timers",
 	description = "PVP Freeze Timers",
-	tags = {"PvP", "Freeze", "Timers"}
+	tags = {"PvP", "Freeze", "Timers"},
+        type = "PVP"
 )
 
 public class FreezeTimersPlugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grotesqueguardians/GrotesqueGuardiansPlugin.java
@@ -30,9 +30,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-	name = "<font color=\"#4863A0\">!Grotesque Guardians</font>",
+	name = "Grotesque Guardians",
 	description = "Display tile indicators for the Grotesque Guardian special attacks",
-	tags = {"grotesque", "guardians", "gargoyle", "garg"}
+	tags = {"grotesque", "guardians", "gargoyle", "garg"},
+		type = "PVM"
 )
 public class GrotesqueGuardiansPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/hideprayers/HidePrayersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/hideprayers/HidePrayersPlugin.java
@@ -20,8 +20,9 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 @PluginDescriptor(
-	name = "<font color=\"green\">!Hide Prayers</font>", 
-	description = "Hides specific Prayers in the Prayer tab."
+	name = "Hide Prayers",
+	description = "Hides specific Prayers in the Prayer tab.",
+		type = "utility"
 )
 public class HidePrayersPlugin extends Plugin {
 	private static final int PRAYER_COUNT = Prayer.values().length;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kittennotifier/KittenNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kittennotifier/KittenNotifierPlugin.java
@@ -14,9 +14,10 @@ import net.runelite.api.Client;
 import javax.inject.Inject;
 
 @PluginDescriptor(
-        name = "!Kitten Notifier",
+        name = "Kitten Notifier",
         description = "Sends a notification when your kitten needs food, attention, or is grown.",
-        tags = {"kitten, notifications"}
+        tags = {"kitten, notifications"},
+        type = "utility"
 )
 public class KittenNotifierPlugin extends Plugin{
     @Inject
@@ -54,7 +55,7 @@ public class KittenNotifierPlugin extends Plugin{
         if (!config.catOwned()) {
             for (NPC npc : client.getNpcs()) {
                 if (npc.getInteracting() != null) {
-                    if (npc.getName().contentEquals("Cat") && !config.catOwned()) {
+                    if (npc.getName().equals("Cat") && !config.catOwned()) {
                         // If this if statement is included in previous it could null.
                         if (npc.getInteracting().getName().contentEquals(client.getLocalPlayer().getName())) {
                             config.catOwned(true);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/lizardmenshaman/LizardmenShamanPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/lizardmenshaman/LizardmenShamanPlugin.java
@@ -19,10 +19,11 @@ import java.util.Map;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-		name = "<font color=\"#4863A0\">!Lizard Shamans</font>",
+		name = "Lizard Shamans",
 		description = "Configures timer for lizardmen shaman spawns.",
 		enabledByDefault = false,
-		tags = {"shaman", "lizard", "lizardmen"}
+		tags = {"shaman", "lizard", "lizardmen"},
+		type = "PVM"
 )
 @Slf4j
 public class LizardmenShamanPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menumodifier/MenuModifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menumodifier/MenuModifierPlugin.java
@@ -25,10 +25,11 @@ import java.util.Iterator;
 import java.util.List;
 
 @PluginDescriptor(
-        name = "<font color=\"green\">!Menu Modifier</font>",
+        name = "Menu Modifier",
         description = "Changes right click menu for players",
         tags = { "menu", "modifier", "right", "click", "pk", "bogla" },
-        enabledByDefault = false
+        enabledByDefault = false,
+        type = "utility"
 )
 public class MenuModifierPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MapLocations.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MapLocations.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import java.awt.Polygon;
 import java.awt.Rectangle;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsConfig.java
@@ -22,15 +22,15 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import java.awt.Color;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("zoneIndicators")
-public interface ZoneIndicatorsConfig extends Config
+@ConfigGroup("multiindicators")
+public interface MultiIndicatorsConfig extends Config
 {
     @ConfigItem(
             keyName = "multicombatZoneVisibility",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsMinimapOverlay.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import java.awt.Color;
 import java.awt.Dimension;
@@ -40,7 +40,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
-public class ZoneIndicatorsMinimapOverlay extends Overlay
+public class MultiIndicatorsMinimapOverlay extends Overlay
 {
     private final static int MAX_LOCAL_DRAW_LENGTH = 20 * Perspective.LOCAL_TILE_SIZE;
 
@@ -48,13 +48,13 @@ public class ZoneIndicatorsMinimapOverlay extends Overlay
     private Client client;
 
     @Inject
-    private ZoneIndicatorsPlugin plugin;
+    private MultiIndicatorsPlugin plugin;
 
     @Inject
-    private ZoneIndicatorsConfig config;
+    private MultiIndicatorsConfig config;
 
     @Inject
-    public ZoneIndicatorsMinimapOverlay()
+    public MultiIndicatorsMinimapOverlay()
     {
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ALWAYS_ON_TOP);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsOverlay.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import java.awt.BasicStroke;
 import java.awt.Color;
@@ -41,7 +41,7 @@ import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
 import net.runelite.client.ui.overlay.OverlayPriority;
 
-public class ZoneIndicatorsOverlay extends Overlay
+public class MultiIndicatorsOverlay extends Overlay
 {
     private final static int MAX_LOCAL_DRAW_LENGTH = 20 * Perspective.LOCAL_TILE_SIZE;
 
@@ -49,13 +49,13 @@ public class ZoneIndicatorsOverlay extends Overlay
     private Client client;
 
     @Inject
-    private ZoneIndicatorsPlugin plugin;
+    private MultiIndicatorsPlugin plugin;
 
     @Inject
-    private ZoneIndicatorsConfig config;
+    private MultiIndicatorsConfig config;
 
     @Inject
-    public ZoneIndicatorsOverlay()
+    public MultiIndicatorsOverlay()
     {
         setPosition(OverlayPosition.DYNAMIC);
         setLayer(OverlayLayer.ABOVE_SCENE);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import net.runelite.client.eventbus.Subscribe;
 import com.google.inject.Provides;
@@ -52,12 +52,13 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-        name = "<font color=\"aqua\">!MultiLines</font>",
+        name = "Multi-Lines",
         description = "Show borders of multicombat and PvP safezones",
         tags = {"multicombat", "lines", "pvp", "deadman", "safezones", "bogla"},
-        enabledByDefault = false
+        enabledByDefault = false,
+        type = "PVP"
 )
-public class ZoneIndicatorsPlugin extends Plugin
+public class MultiIndicatorsPlugin extends Plugin
 {
     @Inject
     private Client client;
@@ -66,13 +67,13 @@ public class ZoneIndicatorsPlugin extends Plugin
     private ClientThread clientThread;
 
     @Inject
-    private ZoneIndicatorsConfig config;
+    private MultiIndicatorsConfig config;
 
     @Inject
-    private ZoneIndicatorsOverlay overlay;
+    private MultiIndicatorsOverlay overlay;
 
     @Inject
-    private ZoneIndicatorsMinimapOverlay minimapOverlay;
+    private MultiIndicatorsMinimapOverlay minimapOverlay;
 
     @Inject
     private OverlayManager overlayManager;
@@ -92,9 +93,9 @@ public class ZoneIndicatorsPlugin extends Plugin
     private int currentPlane;
 
     @Provides
-    ZoneIndicatorsConfig getConfig(ConfigManager configManager)
+    MultiIndicatorsConfig getConfig(ConfigManager configManager)
     {
-        return configManager.getConfig(ZoneIndicatorsConfig.class);
+        return configManager.getConfig(MultiIndicatorsConfig.class);
     }
 
     @Override

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/ZoneVisibility.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/ZoneVisibility.java
@@ -22,7 +22,7 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-package net.runelite.client.plugins.zoneIndicators;
+package net.runelite.client.plugins.multiindicators;
 
 import lombok.RequiredArgsConstructor;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/nexthitnotifier/NextHitNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/nexthitnotifier/NextHitNotifierPlugin.java
@@ -16,10 +16,11 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import javax.inject.Inject;
 
 @PluginDescriptor(
-        name = "<font color=\"green\">!Next Hit Notifier</font>",
+        name = "Next Hit Notifier",
         description = "Shows estimated next hit based on xp drop.",
         tags = { "experience", "damage", "overlay", "pking", "bogla" },
-        enabledByDefault = false
+        enabledByDefault = false,
+        type = "utility"
 )
 public class NextHitNotifierPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pkvision/PKVisionPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pkvision/PKVisionPlugin.java
@@ -18,10 +18,11 @@ import net.runelite.client.util.MiscUtils;
 import net.runelite.client.util.Text;
 
 @PluginDescriptor(
-        name = "<font color=\"aqua\">!PK Vision</font>",
+        name = "PK Vision",
         description = "Highlight players on-screen and/or on the minimap",
         tags = {"highlight", "minimap", "overlay", "players", "pk", "helper", "vision", "bogla"},
-        enabledByDefault = false
+        enabledByDefault = false,
+        type = "PVP"
 )
 public class PKVisionPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterConfig.java
@@ -1,0 +1,60 @@
+package net.runelite.client.plugins.pluginsorter;
+
+import net.runelite.client.config.Config;
+import net.runelite.client.config.ConfigGroup;
+import net.runelite.client.config.ConfigItem;
+
+import java.awt.*;
+
+@ConfigGroup("runelit")
+public interface PluginSorterConfig extends Config {
+
+    Color rlDefault = new Color(250, 155, 23);
+
+    boolean pluginsHidden = false;
+
+    @ConfigItem(
+            position = 0,
+            keyName = "hidePlugins",
+            name = "Hide Plugins",
+            description = "Hides all 3rd party plugins if checked"
+    )
+    default boolean hidePlugins()
+    {
+        return pluginsHidden;
+    }
+
+    @ConfigItem(
+            position = 1,
+            keyName = "pvmColor",
+            name = "PVM color",
+            description = "Configure the color of PVM related plugins"
+    )
+    default Color pvmColor()
+    {
+        return Color.GREEN;
+    }
+
+    @ConfigItem(
+            position = 2,
+            keyName = "pvpColor",
+            name = "PVP color",
+            description = "Configure the color of PVP related plugins"
+    )
+    default Color pvpColor()
+    {
+        return Color.RED;
+    }
+
+    @ConfigItem(
+            position = 3,
+            keyName = "utilityColor",
+            name = "Utility color",
+            description = "Configure the color of utility related plugins"
+    )
+    default Color utilityColor()
+    {
+        return Color.CYAN;
+    }
+
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
@@ -92,7 +92,7 @@ public class PluginSorterPlugin extends Plugin {
         Iterator<PluginListItem> iter = ConfigPanel.pluginList.iterator();
         while (iter.hasNext()) {
             PluginListItem pli = iter.next();
-            if (pli.getPlugin() != null)
+            if (pli.getPlugin() != null) {
                 if (!pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals(""))
                     if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("PVM")) {
                         iter.remove();
@@ -108,6 +108,7 @@ public class PluginSorterPlugin extends Plugin {
                         iter.remove();
                         removedPlugins.add(pli);
                     }
+            }
         }
     }
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
@@ -1,0 +1,124 @@
+package net.runelite.client.plugins.pluginsorter;
+
+import com.google.inject.Provides;
+import net.runelite.api.GameState;
+import net.runelite.api.events.ConfigChanged;
+import net.runelite.api.events.GameStateChanged;
+import net.runelite.client.config.ConfigItemDescriptor;
+import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.plugins.config.ConfigPanel;
+import net.runelite.client.plugins.config.PluginListItem;
+
+import javax.inject.Inject;
+import java.awt.*;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+@PluginDescriptor(
+        name = "Plugin Organizer",
+        description = "Hides and colors 3rd party plugins for better control",
+        tags = {"Fuck RL","Abex is shit :p"},
+        type = "pluginOrganizer"
+)
+public class PluginSorterPlugin extends Plugin {
+
+    //Cache the hidden plugins
+    public static List<PluginListItem> removedPlugins = new ArrayList<>();
+
+    @Inject
+    private PluginSorterConfig config;
+
+    @Provides
+    PluginSorterConfig provideConfig(ConfigManager configManager)
+    {
+        return configManager.getConfig(PluginSorterConfig.class);
+    }
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        updateColors();
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+
+    }
+
+    @Subscribe
+    public void onGameStateChanged (GameStateChanged gameStateChanged)
+    {
+        if (gameStateChanged.getGameState()== GameState.LOGIN_SCREEN) {
+            if (config.hidePlugins())
+                hidePlugins();
+            updateColors();
+        }
+    }
+
+    @Subscribe
+    public void onConfigChanged(ConfigChanged configChanged) {
+        if (configChanged.getKey().equals("hidePlugins")) {
+            if (config.hidePlugins()) {
+                hidePlugins();
+            } else {
+                showPlugins();
+            }
+        }
+        updateColors();
+    }
+
+    public void updateColors() {
+        for (PluginListItem pli : ConfigPanel.pluginList) {
+            if (pli.getPlugin()!=null) {
+                if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type()!=null)
+                    if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("PVM"))
+                        pli.nameLabel.setForeground(config.pvmColor());
+                    else if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("PVP"))
+                        pli.nameLabel.setForeground(config.pvpColor());
+                    else if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("utility"))
+                        pli.nameLabel.setForeground(config.utilityColor());
+                    else
+                        pli.nameLabel.setForeground(Color.WHITE);
+            }
+        }
+    }
+
+    public void hidePlugins() {
+        Iterator<PluginListItem> iter = ConfigPanel.pluginList.iterator();
+        while (iter.hasNext()) {
+            PluginListItem pli = iter.next();
+            if (pli.getPlugin() != null)
+                if (!pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals(""))
+                    if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("PVM")) {
+                        iter.remove();
+                        removedPlugins.add(pli);
+                    }
+                if (!pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals(""))
+                    if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("PVP")) {
+                        iter.remove();
+                        removedPlugins.add(pli);
+                    }
+                if (!pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals(""))
+                    if (pli.getPlugin().getClass().getAnnotation(PluginDescriptor.class).type().equals("utility")) {
+                        iter.remove();
+                        removedPlugins.add(pli);
+                    }
+        }
+    }
+
+    public void showPlugins() {
+        List<PluginListItem> tempList = new ArrayList<>();
+        for (PluginListItem pli : removedPlugins) {
+            tempList.add(pli);
+        }
+        for (PluginListItem pli : ConfigPanel.pluginList) {
+            tempList.add(pli);
+        }
+        ConfigPanel.pluginList = tempList;
+    }
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/prayagainstplayer/PrayAgainstPlayerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/prayagainstplayer/PrayAgainstPlayerPlugin.java
@@ -42,9 +42,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 @PluginDescriptor(
-		name = "<font color=\"aqua\">!Pray Against Player</font>",
+		name = "Pray Against Player",
 		description = "Use plugin in PvP situations for best results!!",
-		tags = {"highlight", "pvp", "overlay", "players"}
+		tags = {"highlight", "pvp", "overlay", "players"},
+		type = "PVP"
 )
 
 /**

--- a/runelite-client/src/main/java/net/runelite/client/plugins/shiftwalker/ShiftWalkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/shiftwalker/ShiftWalkerPlugin.java
@@ -41,10 +41,11 @@ import javax.inject.Inject;
  * Shift Walker Plugin. Credit to MenuEntrySwapperPlugin for code some code structure used here.
  */
 @PluginDescriptor(
-	name = "<font color=\"green\">!Shift To Walk Here</font>",
+	name = "Shift To Walk",
 	description = "Use Shift to toggle the Walk Here menu option. While pressed you will Walk rather than interact with objects.",
 	tags = {"npcs", "items", "objects"},
-	enabledByDefault = false
+	enabledByDefault = false,
+		type = "utility"
 )
 public class ShiftWalkerPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/SlayermusiqPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/SlayermusiqPlugin.java
@@ -76,9 +76,10 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
 @PluginDescriptor(
-	name = "<font color=\"green\">!Slayermusiq1 Guides</font>",
+	name = "Slayermusiq1 Guides",
 	description = "Adds a right-click option to go to Slayermusiq1's guides from the quest tab",
-	tags = {"quest", "guide", "slayermusiq"}
+	tags = {"quest", "guide", "slayermusiq"},
+		type = "utility"
 )
 @Slf4j
 public class SlayermusiqPlugin extends Plugin

--- a/runelite-client/src/main/java/net/runelite/client/plugins/tickcounter/TickCounterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tickcounter/TickCounterPlugin.java
@@ -21,9 +21,10 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
-@PluginDescriptor(name = "<font color=\"green\">!Tick Counter</font>",
+@PluginDescriptor(name = "Tick Counter",
 		description = "Counts combat activity for nearby players",
-		enabledByDefault = false
+		enabledByDefault = false,
+		type = "utility"
 )
 public class TickCounterPlugin extends Plugin {
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/vetion/VetionPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/vetion/VetionPlugin.java
@@ -40,9 +40,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 @PluginDescriptor(
-        name = "<font color=\"#4863A0\">!Vetion</font>",
+        name = "Vetion",
         description = "Tracks Vet'ion's special attacks",
-        tags = {"bosses", "combat", "pve", "overlay"}
+        tags = {"bosses", "combat", "pve", "overlay"},
+        type = "PVM"
 )
 public class VetionPlugin extends Plugin {
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/vorkath/VorkathPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/vorkath/VorkathPlugin.java
@@ -14,9 +14,10 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import org.apache.commons.lang3.ArrayUtils;
 
 @PluginDescriptor(
-	name = "<font color=\"#4863A0\">!Vorkath</font>",
+	name = "Vorkath",
 	description = "Vorkath Helper",
-	tags = {"Vorkath", "Helper"}
+	tags = {"Vorkath", "Helper"},
+		type = "PVM"
 )
 public class VorkathPlugin extends Plugin
 {

--- a/runelite-client/src/main/java/net/runelite/client/plugins/ztob/TheatrePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/ztob/TheatrePlugin.java
@@ -26,9 +26,10 @@ import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(
-        name = "<font color=\"#4863A0\">!Theatre of Blood</font>",
+        name = "Theatre of Blood",
         description = "All-in-one plugin for Theatre of Blood",
         tags = {"ToB"},
+        type = "PVM",
         enabledByDefault = false
 )
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/zulrah/ZulrahPlugin.java
@@ -21,9 +21,10 @@ import net.runelite.client.ui.overlay.OverlayManager;
 import net.runelite.client.util.ImageUtil;
 
 @PluginDescriptor(
-	name = "<font color=\"#4863A0\">!Zulrah</font>",
+	name = "Zulrah",
 	description = "Zulrah Helper",
-	tags = {"Zulrah", "Helper"}
+	tags = {"Zulrah", "Helper"},
+		type = "PVM"
 )
 public class ZulrahPlugin extends Plugin
 {


### PR DESCRIPTION
Allows Hiding, and recoloring of types of plugins:

Currently Types are PVM, PVP, Utility

All types are organized alphabetically individually

Types are declared in PluginDescriptor as type = "PVP" etc

HTML tags are removed, and we use Java colors now

All current plugins updated to use the new system

Plugin Organizer is located at the bottom of plugin list for less visibilty.

Plugins enabled/disabled is remembered and applied automatically on startup

![dvya9GbVK1](https://user-images.githubusercontent.com/2943260/56455223-be5bb180-6329-11e9-966d-0384aea4359a.gif)
