### PR TITLE
ByteCodePatcher

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/ByteCodePatcher.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/ByteCodePatcher.java
@@ -9,6 +9,7 @@ import net.runelite.client.RuneLite;
 import net.runelite.client.rs.ClientLoader;
 import net.runelite.client.rs.bytecode.transformers.ActorTransform;
 import net.runelite.client.rs.bytecode.transformers.ClientTransform;
+import net.runelite.client.rs.bytecode.transformers.ErrorTransform;
 import net.runelite.client.rs.bytecode.transformers.PlayerTransform;
 import net.runelite.client.rs.bytecode.transformers.ProjectileTransform;
 import net.runelite.http.api.RuneLiteAPI;
@@ -50,10 +51,12 @@ public class ByteCodePatcher {
 				transformProjectile(projectileClass);
 				Class playerClass = Class.forName(hooks.playerClass, false, child);
 				transformPlayer(playerClass);
-
-				//experimental
 				Class clientClass = Class.forName("client", false, child);
 				transformBlackjack(clientClass);
+
+				//Odds and ends
+				ErrorTransform et = new ErrorTransform();
+				et.modify(null);
 
 				ByteCodeUtils.updateHijackedJar();
 			} catch (Exception e) {

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ErrorTransform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ErrorTransform.java
@@ -1,0 +1,36 @@
+package net.runelite.client.rs.bytecode.transformers;
+
+import javassist.CtClass;
+import javassist.CtMethod;
+import javassist.CtNewMethod;
+import net.runelite.client.rs.bytecode.ByteCodePatcher;
+
+//This prevents the client from sending stack traces to Jagex at all, even classes outside of runelite.
+public class ErrorTransform implements Transform {
+    public CtClass ct = null;
+
+    //Where Runelites error interceptor is located, not auto-scraped.
+    private final String ERROR_INSTANCE_CLASS = "dp";
+    private final String ERROR_INSTANCE_METHOD = "a";
+
+    @Override
+    public void modify(Class clazz) {
+        try {
+            System.out.println("[RuneLit] Transforming error method at class: "+ERROR_INSTANCE_CLASS);
+            ct = ByteCodePatcher.classPool.get(ERROR_INSTANCE_CLASS);
+            CtMethod error = ct.getDeclaredMethod(ERROR_INSTANCE_METHOD);
+            ct.removeMethod(error);
+            error = CtMethod.make("public static void a(String string, Throwable throwable, byte by) {"+
+                    "                   return;"+
+                    "                   }", ct);
+            ct.addMethod(error);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override
+    public void transform() {
+
+    }
+}


### PR DESCRIPTION
Adds ErrorTransform
-This prevents the client from sending any stack traces to Jagex. (a huge client detection system they use)

(also classes contained in the runelite package should already be ignored but this is to be sure, and include libraries such as natural mouse motion from sending errors too.)