### PR TITLE
Alch hydra: Improve poison overlay, add defence overlay, bugfixes

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/Hydra.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/Hydra.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, https://runelitepl.us
+ * Copyright (c) 2019, Lucas <https://github.com/lucwousin>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,6 +27,7 @@ package net.runelite.client.plugins.alchemicalhydra;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.NPC;
 import net.runelite.api.Prayer;
 import net.runelite.api.ProjectileID;
 
@@ -52,6 +53,9 @@ class Hydra
 	}
 
 	@Getter
+	private NPC npc;
+
+	@Getter
 	@Setter
 	private HydraPhase phase;
 
@@ -75,12 +79,19 @@ class Hydra
 	@Setter
 	private AttackStyle lastAttack;
 
-	Hydra()
+	@Getter
+	@Setter
+	private boolean weakened;
+
+	Hydra(NPC npc)
 	{
+		this.npc = npc;
 		this.phase = HydraPhase.ONE;
 		this.nextAttack = AttackStyle.MAGIC;
+		this.lastAttack = AttackStyle.MAGIC; // important, else we wouldn't switch if the first attack is ranged
 		this.nextSpecial = 3;
 		this.nextSwitch = phase.getAttacksPerSwitch();
 		this.attackCount = 0;
+		this.weakened = false;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, https://runelitepl.us
+ * Copyright (c) 2019, Lucas <https://github.com/lucwousin>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPhase.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPhase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, https://runelitepl.us
+ * Copyright (c) 2019, Lucas <https://github.com/lucwousin>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,33 +28,37 @@ import lombok.Getter;
 import net.runelite.api.AnimationID;
 import net.runelite.api.ProjectileID;
 import net.runelite.api.SpriteID;
+import net.runelite.api.coords.WorldPoint;
 
 enum HydraPhase
-{
-	ONE(3, AnimationID.HYDRA_1_1, AnimationID.HYDRA_1_2, ProjectileID.HYDRA_POISON, 0, SpriteID.BIG_ASS_GUTHIX_SPELL),
-	TWO(3, AnimationID.HYDRA_2_1, AnimationID.HYDRA_2_2, 0, AnimationID.HYDRA_LIGHTNING, SpriteID.BIG_SPEC_TRANSFER),
-	THREE(3, AnimationID.HYDRA_3_1, AnimationID.HYDRA_3_2, 0, AnimationID.HYDRA_FIRE, SpriteID.BIG_SUPERHEAT),
-	FOUR(1, AnimationID.HYDRA_4_1, AnimationID.HYDRA_4_2, ProjectileID.HYDRA_POISON, 0, SpriteID.BIG_ASS_GUTHIX_SPELL);
+{ // Sorry for the autism
+	ONE		(3, AnimationID.HYDRA_1_1, AnimationID.HYDRA_1_2, ProjectileID.HYDRA_POISON, 0, SpriteID.BIG_ASS_GUTHIX_SPELL, new WorldPoint(1371, 10263, 0)),
+	TWO		(3, AnimationID.HYDRA_2_1, AnimationID.HYDRA_2_2, 0, AnimationID.HYDRA_LIGHTNING, SpriteID.BIG_SPEC_TRANSFER, new WorldPoint(1371, 10272, 0)),
+	THREE	(3, AnimationID.HYDRA_3_1, AnimationID.HYDRA_3_2, 0, AnimationID.HYDRA_FIRE, SpriteID.BIG_SUPERHEAT, new WorldPoint(1362, 10272, 0)),
+	FOUR	(1, AnimationID.HYDRA_4_1, AnimationID.HYDRA_4_2, ProjectileID.HYDRA_POISON, 0, SpriteID.BIG_ASS_GUTHIX_SPELL, null);
 
 	@Getter
-	private int attacksPerSwitch;
+	private final int attacksPerSwitch;
 
 	@Getter
-	private int deathAnim1;
+	private final int deathAnim1;
 
 	@Getter
-	private int deathAnim2;
+	private final int deathAnim2;
 
 	@Getter
-	private int specProjectileId;
+	private final int specProjectileId;
 
 	@Getter
-	private int specAnimationId;
+	private final int specAnimationId;
 
 	@Getter
-	private int specImage;
+	private final int specImage;
 
-	HydraPhase(int attacksPerSwitch, int deathAnim1, int deathAnim2, int specProjectileId, int specAnimationId, int specImage)
+	@Getter
+	private WorldPoint fountain;
+
+	HydraPhase(int attacksPerSwitch, int deathAnim1, int deathAnim2, int specProjectileId, int specAnimationId, int specImage, WorldPoint fountain)
 	{
 		this.attacksPerSwitch = attacksPerSwitch;
 		this.deathAnim1 = deathAnim1;
@@ -62,5 +66,6 @@ enum HydraPhase
 		this.specProjectileId = specProjectileId;
 		this.specAnimationId = specAnimationId;
 		this.specImage = specImage;
+		this.fountain = fountain;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPoisonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPoisonOverlay.java
@@ -37,6 +37,7 @@ import net.runelite.api.Client;
 import static net.runelite.api.Perspective.getCanvasTileAreaPoly;
 import net.runelite.api.Projectile;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldArea;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -111,29 +112,30 @@ class HydraPoisonOverlay extends Overlay
 			return;
 		}
 
-		LocalPoint fountainPoint = null;
-
+		WorldPoint wp = null;
 		for (WorldPoint p : fountainWorldPoint) // this
 		{
-			fountainPoint = LocalPoint.fromWorld(client, p); // trash
+			wp = p;
 		}
 
-		if (fountainPoint == null || hydra.isWeakened())
+		LocalPoint fountainPoint = wp == null ? null : LocalPoint.fromWorld(client, wp); // trash
+
+		if (fountainPoint == null || hydra.isWeakened()) // I
 		{
 			return;
 		}
 
-		final Polygon poly = getCanvasTileAreaPoly(client, fountainPoint, 3);
+		final Polygon poly = getCanvasTileAreaPoly(client, fountainPoint, 3); // don't
 
 		if (poly == null)
 		{
 			return;
 		}
 
-		Color color = new Color(255, 0, 0, 100);
+		Color color = new Color(255, 0, 0, 100); // like
 
-		if (poly.getBounds().intersects(hydra.getNpc().getCanvasTilePoly().getBounds()))
-		{
+		if (hydra.getNpc().getWorldArea().intersectsWith(new WorldArea(wp.getX() - 1, wp.getY() - 1, 3, 3, wp.getPlane()))) 	// coords
+		{																														// WHICH FUCKING RETARD DID X, Y, dX, dY, Z???? IT'S XYZdXdY REEEEEEEEEE
 			color = new Color(0, 255, 0, 100);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPoisonOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPoisonOverlay.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, https://runelitepl.us
+ * Copyright (c) 2019, Lucas <https://github.com/lucwousin>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -29,12 +29,15 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.geom.Area;
-import java.util.HashSet;
+import java.util.Collection;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import net.runelite.api.Client;
 import static net.runelite.api.Perspective.getCanvasTileAreaPoly;
+import net.runelite.api.Projectile;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -57,29 +60,84 @@ class HydraPoisonOverlay extends Overlay
 	@Override
 	public Dimension render(Graphics2D graphics)
 	{
-		final HashSet<LocalPoint> initialPoints = plugin.getPoisonPoints();
-		Area poisonTiles = new Area();
-		for (LocalPoint point : initialPoints)
-		{
-			Polygon poly = getCanvasTileAreaPoly(client, point, 3);
-			if (poly == null)
-			{
-				break;
-			}
+		Hydra hydra = plugin.getHydra();
+		final Map<LocalPoint, Projectile> poisonProjectiles = plugin.getPoisonProjectiles();
 
-			poisonTiles.add(new Area(poly));
+		if (!poisonProjectiles.isEmpty())
+		{
+			drawPoisonArea(graphics, poisonProjectiles);
 		}
 
-		if (poisonTiles.isEmpty())
+		if (hydra.getPhase().getFountain() != null)
 		{
-			return null;
+			drawFountain(graphics, hydra);
 		}
-		graphics.setPaintMode();
-		graphics.setColor(new Color(255, 0, 0, 75));
-		graphics.draw(poisonTiles);
-		graphics.setColor(new Color(255, 0, 0, 30));
-		graphics.fill(poisonTiles);
 
 		return null;
+	}
+
+	private void drawPoisonArea(Graphics2D graphics, Map<LocalPoint, Projectile> poisonProjectiles)
+	{
+		Area poisonTiles = new Area();
+
+		for (Map.Entry<LocalPoint, Projectile> entry : poisonProjectiles.entrySet())
+		{
+			if (entry.getValue().getEndCycle() < client.getGameCycle())
+			{
+				continue;
+			}
+
+			LocalPoint point = entry.getKey();
+			Polygon poly = getCanvasTileAreaPoly(client, point, 3);
+
+			if (poly != null)
+			{
+			poisonTiles.add(new Area(poly));
+		}
+		}
+
+		graphics.setPaintMode();
+		graphics.setColor(new Color(255, 0, 0, 100));
+		graphics.draw(poisonTiles);
+		graphics.setColor(new Color(255, 0, 0, 50));
+		graphics.fill(poisonTiles);
+	}
+
+	private void drawFountain(Graphics2D graphics, Hydra hydra)
+	{
+		Collection<WorldPoint> fountainWorldPoint = WorldPoint.toLocalInstance(client, hydra.getPhase().getFountain()); // thanks
+		if (fountainWorldPoint.size() > 1) // for
+		{
+			return;
+		}
+
+		LocalPoint fountainPoint = null;
+
+		for (WorldPoint p : fountainWorldPoint) // this
+		{
+			fountainPoint = LocalPoint.fromWorld(client, p); // trash
+		}
+
+		if (fountainPoint == null || hydra.isWeakened())
+		{
+			return;
+		}
+
+		final Polygon poly = getCanvasTileAreaPoly(client, fountainPoint, 3);
+
+		if (poly == null)
+		{
+			return;
+		}
+
+		Color color = new Color(255, 0, 0, 100);
+
+		if (poly.getBounds().intersects(hydra.getNpc().getCanvasTilePoly().getBounds()))
+		{
+			color = new Color(0, 255, 0, 100);
+		}
+
+		graphics.setColor(color);
+		graphics.draw(poly);
 	}
 }


### PR DESCRIPTION
Other than improving recovery from unexpected situations and improving poison overlay add a fountain outline, (shows up red if the hydra is not on it, green if it's on it, and dissappears when the hydra reeee'd)