### PR TITLE
XPdrop: Don't show damage indicators on fishing spots

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/experiencedrop/XpDropPlugin.java
@@ -378,6 +378,11 @@ public class XpDropPlugin extends Plugin
 			lastTime = Instant.now();
 			return;
 		}
+		else if (opponent.getName().equalsIgnoreCase("fishing spot"))
+		{
+			lastTime = Instant.now().minus(WAIT);
+			return;
+		}
 
 		damage = 0;
 		lastOpponent = opponent;


### PR DESCRIPTION
kyleToday at 12:38 PM
> @formatme
> That damage xp drop whilst fishing
> What a ducking nightmare that will be to fix

`Showing 1 changed file with 5 additions and 0 deletions. `