### PR TITLE
load spells only once per rebuild instead of before adding a new spell

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/spellbook/SpellbookPlugin.java
@@ -201,13 +201,15 @@ public class SpellbookPlugin extends Plugin
 		String[] sStack = client.getStringStack();
 		int sStackSize = client.getStringStackSize();
 
-		if ("shouldFilterSpell".equals(event.getEventName()))
+		if ("startSpellRedraw".equals(event.getEventName()))
+		{
+			spellbook = Spellbook.getByID(client.getVar(Varbits.SPELLBOOK));
+			loadSpells();
+		}
+		else if ("shouldFilterSpell".equals(event.getEventName()))
 		{
 			String spell = sStack[sStackSize - 1].toLowerCase();
 			int widget = iStack[iStackSize - 1];
-
-			spellbook = Spellbook.getByID(client.getVar(Varbits.SPELLBOOK));
-			loadSpells();
 
 			// Add the spell to spells
 			if (!spells.containsKey(widget))
@@ -341,13 +343,16 @@ public class SpellbookPlugin extends Plugin
 		{
 			return;
 		}
+
 		spells.clear();
+
 		String cfg = configManager.getConfiguration("spellbook", spellbook.getConfigKey());
 
 		if (Strings.isNullOrEmpty(cfg))
 		{
 			return;
 		}
+
 		// CHECKSTYLE:OFF
 		Collection<Spell> gson = GSON.fromJson(cfg, new TypeToken<List<Spell>>(){}.getType());
 		// CHECKSTYLE:ON

--- a/runelite-client/src/main/scripts/MagicSpellBookRedraw.rs2asm
+++ b/runelite-client/src/main/scripts/MagicSpellBookRedraw.rs2asm
@@ -3,6 +3,8 @@
 .string_stack_count 2
 .int_var_count      30
 .string_var_count   2
+   sconst                 "startSpellRedraw"
+   runelite_callback
    iconst                 190
    istore                 11
    iconst                 261


### PR DESCRIPTION
This fixes a npe when loading the plugin with empty config (aka everyone)

you can run maven on only client to make it go by faster, sorry :(