### PR TITLE
Cleanup in transforms and add projectile.getInteracting() transform

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Projectile.java
+++ b/runelite-api/src/main/java/net/runelite/api/Projectile.java
@@ -38,6 +38,13 @@ public interface Projectile extends Renderable
 	int getId();
 
 	/**
+	 * Gets the actor that is targeted by this projectile.
+	 *
+	 * @return the target actor, or null if this projectile is an AoE attack
+	 */
+	Actor getInteracting();
+
+	/**
 	 * Gets the original x-axis coordinate that this projectile started from.
 	 *
 	 * @return the original coordinate

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsOverlay.java
@@ -38,6 +38,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.Setter;
+import net.runelite.api.Actor;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.DecorativeObject;
@@ -391,15 +392,36 @@ class DevToolsOverlay extends Overlay
 
 		for (Projectile projectile : projectiles)
 		{
-			int projectileId = projectile.getId();
-			String text = "(ID: " + projectileId + ")";
-			int x = (int) projectile.getX();
-			int y = (int) projectile.getY();
-			LocalPoint projectilePoint = new LocalPoint(x, y);
-			Point textLocation = Perspective.getCanvasTextLocation(client, graphics, projectilePoint, text, 0);
-			if (textLocation != null)
+			int originX = projectile.getX1();
+			int originY = projectile.getY1();
+
+			LocalPoint tilePoint = new LocalPoint(originX, originY);
+			Polygon poly = Perspective.getCanvasTilePoly(client, tilePoint);
+
+			if (poly != null)
 			{
-				OverlayUtil.renderTextLocation(graphics, textLocation, text, Color.RED);
+				OverlayUtil.renderPolygon(graphics, poly, Color.RED);
+			}
+
+			int projectileId = projectile.getId();
+			Actor projectileInteracting = projectile.getInteracting();
+
+			String infoString = "";
+
+			if (projectileInteracting == null)
+			{
+				infoString += "AoE";
+			}
+			else
+			{
+				infoString += "Targeted (T: " + projectileInteracting.getName() + ")";
+			}
+
+			infoString += " (ID: " + projectileId + ")";
+
+			if (projectileInteracting != null)
+			{
+				OverlayUtil.renderActorOverlay(graphics, projectile.getInteracting(), infoString, Color.RED);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ClientTransform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ClientTransform.java
@@ -1,25 +1,24 @@
 package net.runelite.client.rs.bytecode.transformers;
 
-import javassist.CtBehavior;
+import javassist.CannotCompileException;
 import javassist.CtClass;
-import javassist.CtField;
-import javassist.CtMember;
 import javassist.CtMethod;
 import javassist.CtNewMethod;
+import javassist.NotFoundException;
 import javassist.bytecode.AnnotationsAttribute;
 import javassist.bytecode.ClassFile;
 import javassist.bytecode.ConstPool;
-import javassist.bytecode.StackMapTable;
 import net.runelite.client.rs.bytecode.ByteCodePatcher;
 
 public class ClientTransform implements Transform {
 
-	public CtClass ct = null;
+	private CtClass ct;
 
 	@Override
 	public void modify(Class clazz) {
 		try {
 			ct = ByteCodePatcher.classPool.get(clazz.getName());
+
 			transformProtectedGetMenuOptions();
 			transformProtectedGetMenuTargets();
 			transformProtectedGetMenuIdentifiers();
@@ -42,176 +41,166 @@ public class ClientTransform implements Transform {
 		}
 	}
 
-	public void transformProtectedGetMenuOptions() {
+	private void transformProtectedGetMenuOptions() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuOptions;
-		try {
-			protectedGetMenuOptions = ct.getDeclaredMethod("1protect$getMenuOptions");
-			ct.removeMethod(protectedGetMenuOptions);
-			protectedGetMenuOptions.setName("getMenuOptions");
-			ct.addMethod(protectedGetMenuOptions);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		protectedGetMenuOptions = ct.getDeclaredMethod("1protect$getMenuOptions");
+		ct.removeMethod(protectedGetMenuOptions);
+
+		protectedGetMenuOptions.setName("getMenuOptions");
+		ct.addMethod(protectedGetMenuOptions);
 	}
 
-    public void transformGetProjectiles() {
-
+    private void transformGetProjectiles() throws CannotCompileException, NotFoundException
+	{
         CtMethod getProjectiles;
-        try {
-            CtMethod getProjectilesDeque = ct.getDeclaredMethod("1protect$getProjectilesDeque");
-            ct.removeMethod(getProjectilesDeque);
-			getProjectilesDeque.setName("getProjectilesDeque");
-            ct.addMethod(getProjectilesDeque);
-            getProjectiles = ct.getDeclaredMethod("getProjectiles");
-            ct.removeMethod(getProjectiles);
-            getProjectiles = CtNewMethod.make("public java.util.List getProjectiles() { " +
-                    "                               java.util.ArrayList localArrayList = new java.util.ArrayList();" +
-                    "                               net.runelite.rs.api.RSDeque localRSDeque = getProjectilesDeque();" +
-                    "                               net.runelite.rs.api.RSNode localRSNode = localRSDeque.getHead();" +
-                    "                               for (net.runelite.api.Node localNode = localRSNode.getNext(); localNode != localRSNode; localNode = localNode.getNext()) {" +
-                    "                                   net.runelite.api.Projectile localProjectile = (net.runelite.api.Projectile)localNode;" +
-                    "                                   localArrayList.add(localProjectile);  }" +
-                    "                               return localArrayList; }", ct);
 
-            ct.addMethod(getProjectiles);
-            ClassFile classFile = ct.getClassFile();
-            ConstPool constPool = classFile.getConstPool();
-            AnnotationsAttribute attr = new AnnotationsAttribute(constPool, AnnotationsAttribute.visibleTag);
-            javassist.bytecode.annotation.Annotation annotation = new javassist.bytecode.annotation.Annotation("Override", constPool);
-            attr.setAnnotation(annotation);
-            getProjectiles.getMethodInfo().addAttribute(attr);
-            System.out.println("Added override annotation for getprojectiles");
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+        CtMethod getProjectilesDeque = ct.getDeclaredMethod("1protect$getProjectilesDeque");
+        ct.removeMethod(getProjectilesDeque);
+
+        getProjectilesDeque.setName("getProjectilesDeque");
+        ct.addMethod(getProjectilesDeque);
+
+        getProjectiles = ct.getDeclaredMethod("getProjectiles");
+        ct.removeMethod(getProjectiles);
+
+        getProjectiles = CtNewMethod.make(
+        	"public java.util.List getProjectiles() { " +
+                	"java.util.ArrayList localArrayList = new java.util.ArrayList();" +
+                	"net.runelite.rs.api.RSDeque localRSDeque = getProjectilesDeque();" +
+                	"net.runelite.rs.api.RSNode localRSNode = localRSDeque.getHead();" +
+                	"for (net.runelite.api.Node localNode = localRSNode.getNext(); localNode != localRSNode; localNode = localNode.getNext()) {" +
+                		"net.runelite.api.Projectile localProjectile = (net.runelite.api.Projectile)localNode;" +
+                		"localArrayList.add(localProjectile);  }" +
+                	"return localArrayList; }", ct);
+        ct.addMethod(getProjectiles);
+
+        ClassFile classFile = ct.getClassFile();
+        ConstPool constPool = classFile.getConstPool();
+        AnnotationsAttribute attr = new AnnotationsAttribute(constPool, AnnotationsAttribute.visibleTag);
+        javassist.bytecode.annotation.Annotation annotation = new javassist.bytecode.annotation.Annotation("Override", constPool);
+        attr.setAnnotation(annotation);
+        getProjectiles.getMethodInfo().addAttribute(attr);
+        System.out.println("Added override annotation for getprojectiles");
     }
-	public void transformProtectedGetMenuTargets() {
+
+	private void transformProtectedGetMenuTargets() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuTargets;
-		try {
-			protectedGetMenuTargets = ct.getDeclaredMethod("1protect$getMenuTargets");
-			ct.removeMethod(protectedGetMenuTargets);
-			protectedGetMenuTargets.setName("getMenuTargets");
-			ct.addMethod(protectedGetMenuTargets);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		protectedGetMenuTargets = ct.getDeclaredMethod("1protect$getMenuTargets");
+		ct.removeMethod(protectedGetMenuTargets);
+
+		protectedGetMenuTargets.setName("getMenuTargets");
+		ct.addMethod(protectedGetMenuTargets);
 	}
 
-    public void transformGetCollisionMaps() {
+    private void transformGetCollisionMaps() throws CannotCompileException, NotFoundException
+	{
         CtMethod getCollisionMaps;
-        try {
-            CtMethod protectedMaps = ct.getDeclaredMethod("1protect$getRsCollisionMaps");
-            ct.removeMethod(protectedMaps);
-            protectedMaps.setName("getRsCollisionMaps");
-            ct.addMethod(protectedMaps);
-            getCollisionMaps = ct.getDeclaredMethod("getCollisionMaps");
-            ct.removeMethod(getCollisionMaps);
-            getCollisionMaps = CtMethod.make("public net.runelite.rs.api.RSCollisionData[] getCollisionMaps() {" +
-                    "								return getRsCollisionMaps();" +
-                    "							}", ct);
-            ct.addMethod(getCollisionMaps);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+
+        CtMethod protectedMaps = ct.getDeclaredMethod("1protect$getRsCollisionMaps");
+        ct.removeMethod(protectedMaps);
+
+        protectedMaps.setName("getRsCollisionMaps");
+        ct.addMethod(protectedMaps);
+
+        getCollisionMaps = ct.getDeclaredMethod("getCollisionMaps");
+        ct.removeMethod(getCollisionMaps);
+
+        getCollisionMaps = CtMethod.make("public net.runelite.rs.api.RSCollisionData[] getCollisionMaps() {	return getRsCollisionMaps(); }", ct);
+        ct.addMethod(getCollisionMaps);
     }
-	public void transformProtectedGetMenuIdentifiers() {
+
+	private void transformProtectedGetMenuIdentifiers() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuIdentifiers;
-		try {
-			protectedGetMenuIdentifiers = ct.getDeclaredMethod("1protect$getMenuIdentifiers");
-			ct.removeMethod(protectedGetMenuIdentifiers);
-			protectedGetMenuIdentifiers.setName("getMenuIdentifiers");
-			ct.addMethod(protectedGetMenuIdentifiers);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		protectedGetMenuIdentifiers = ct.getDeclaredMethod("1protect$getMenuIdentifiers");
+		ct.removeMethod(protectedGetMenuIdentifiers);
+
+		protectedGetMenuIdentifiers.setName("getMenuIdentifiers");
+		ct.addMethod(protectedGetMenuIdentifiers);
 	}
 
-	public void transformProtectedGetMenuTypes() {
+	private void transformProtectedGetMenuTypes() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuTypes;
-		try {
-			protectedGetMenuTypes = ct.getDeclaredMethod("1protect$getMenuTypes");
-			// Don't remove as this is referenced elsewhere in client
-			//ct.removeMethod(protectedGetMenuTypes);
-			CtMethod newProtectedGetMenuTypes = CtNewMethod.copy(protectedGetMenuTypes, ct, null);
-			newProtectedGetMenuTypes.setName("getMenuTypes");
-			ct.addMethod(newProtectedGetMenuTypes);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+		protectedGetMenuTypes = ct.getDeclaredMethod("1protect$getMenuTypes");
+
+		// Don't remove as this is referenced elsewhere in client
+		//ct.removeMethod(protectedGetMenuTypes);
+
+		CtMethod newProtectedGetMenuTypes = CtNewMethod.copy(protectedGetMenuTypes, ct, null);
+		newProtectedGetMenuTypes.setName("getMenuTypes");
+
+		ct.addMethod(newProtectedGetMenuTypes);
 	}
 
-	public void transformProtectedGetMenuActionParams0() {
+	private void transformProtectedGetMenuActionParams0() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuActionParams0;
-		try {
-			protectedGetMenuActionParams0 = ct.getDeclaredMethod("1protect$getMenuActionParams0");
-			ct.removeMethod(protectedGetMenuActionParams0);
-			protectedGetMenuActionParams0.setName("getMenuActionParams0");
-			ct.addMethod(protectedGetMenuActionParams0);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		protectedGetMenuActionParams0 = ct.getDeclaredMethod("1protect$getMenuActionParams0");
+		ct.removeMethod(protectedGetMenuActionParams0);
+
+		protectedGetMenuActionParams0.setName("getMenuActionParams0");
+		ct.addMethod(protectedGetMenuActionParams0);
 	}
 
-	public void transformProtectedGetMenuActionParams1() {
+	private void transformProtectedGetMenuActionParams1() throws CannotCompileException, NotFoundException
+	{
 		CtMethod protectedGetMenuActionParams1;
-		try {
-			protectedGetMenuActionParams1 = ct.getDeclaredMethod("1protect$getMenuActionParams1");
-			ct.removeMethod(protectedGetMenuActionParams1);
-			protectedGetMenuActionParams1.setName("getMenuActionParams1");
-			ct.addMethod(protectedGetMenuActionParams1);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		protectedGetMenuActionParams1 = ct.getDeclaredMethod("1protect$getMenuActionParams1");
+		ct.removeMethod(protectedGetMenuActionParams1);
+		protectedGetMenuActionParams1.setName("getMenuActionParams1");
+		ct.addMethod(protectedGetMenuActionParams1);
 	}
 
-	@Override
-	public void transform() {}
-
-	public void transformGetMenuEntries() {
+	private void transformGetMenuEntries() throws CannotCompileException, NotFoundException
+	{
 		CtMethod getMenuEntries;
-		try {
-			getMenuEntries = ct.getDeclaredMethod("getMenuEntries");
-			ct.removeMethod(getMenuEntries);
-			getMenuEntries = CtMethod.make("public net.runelite.api.MenuEntry[] getMenuEntries() {" +
-					"								int n2 = this.getMenuOptionCount();"+
-					"								String[] arrstring = this.getMenuOptions();"+
-					"								String[] arrstring2 = this.getMenuTargets();"+
-					"								int[] arrn = this.getMenuIdentifiers();"+
-					"								int[] arrn2 = this.getMenuTypes();"+
-					"								int[] arrn3 = this.getMenuActionParams0();"+
-					"								int[] arrn4 = this.getMenuActionParams1();"+
-					"								boolean[] arrbl = this.getMenuForceLeftClick();"+
-					"								net.runelite.api.MenuEntry[] arrmenuEntry = new net.runelite.api.MenuEntry[n2];"+
-					"								int n3 = 0;"+
-					"								while (n3 < n2) {"+
-					"									net.runelite.api.MenuEntry menuEntry = arrmenuEntry[n3] = new net.runelite.api.MenuEntry();"+
-					"									menuEntry.setOption(arrstring[n3]);"+
-					"									menuEntry.setTarget(arrstring2[n3]);"+
-					"									menuEntry.setIdentifier(arrn[n3]);"+
-					"									menuEntry.setType(arrn2[n3]);"+
-					"									menuEntry.setParam0(arrn3[n3]);"+
-					"									menuEntry.setParam1(arrn4[n3]);"+
-					"									menuEntry.setForceLeftClick(arrbl[n3]);"+
-					"									++n3;"+
-					"								}"+
-					"								return arrmenuEntry;"+
-					"							}", ct);
-			ct.addMethod(getMenuEntries);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		getMenuEntries = ct.getDeclaredMethod("getMenuEntries");
+		ct.removeMethod(getMenuEntries);
+
+		getMenuEntries = CtMethod.make(
+			"public net.runelite.api.MenuEntry[] getMenuEntries() {" +
+					"int n2 = this.getMenuOptionCount();"+
+					"String[] arrstring = this.getMenuOptions();"+
+					"String[] arrstring2 = this.getMenuTargets();"+
+					"int[] arrn = this.getMenuIdentifiers();"+
+					"int[] arrn2 = this.getMenuTypes();"+
+					"int[] arrn3 = this.getMenuActionParams0();"+
+					"int[] arrn4 = this.getMenuActionParams1();"+
+					"boolean[] arrbl = this.getMenuForceLeftClick();"+
+					"net.runelite.api.MenuEntry[] arrmenuEntry = new net.runelite.api.MenuEntry[n2];"+
+					"int n3 = 0;"+
+					"while (n3 < n2) {"+
+						"net.runelite.api.MenuEntry menuEntry = arrmenuEntry[n3] = new net.runelite.api.MenuEntry();"+
+						"menuEntry.setOption(arrstring[n3]);"+
+						"menuEntry.setTarget(arrstring2[n3]);"+
+						"menuEntry.setIdentifier(arrn[n3]);"+
+						"menuEntry.setType(arrn2[n3]);"+
+						"menuEntry.setParam0(arrn3[n3]);"+
+						"menuEntry.setParam1(arrn4[n3]);"+
+						"menuEntry.setForceLeftClick(arrbl[n3]);"+
+						"++n3; }"+
+					"return arrmenuEntry; }", ct);
+		ct.addMethod(getMenuEntries);
 	}
 
-	public void transformSetMenuEntries() {
+	private void transformSetMenuEntries() throws CannotCompileException, NotFoundException {
 		CtMethod setMenuEntries;
-		try {
-			setMenuEntries = ct.getDeclaredMethod("setMenuEntries");
-			ct.removeMethod(setMenuEntries);
-			String src;
-			setMenuEntries = CtNewMethod.make(
-					"public void setMenuEntries(net.runelite.api.MenuEntry[] arrmenuEntry) {" +
-							"int n2 = 0;" +
-							"String[] arrstring = this.getMenuOptions();" +
+
+		setMenuEntries = ct.getDeclaredMethod("setMenuEntries");
+		ct.removeMethod(setMenuEntries);
+		setMenuEntries = CtNewMethod.make(
+				"public void setMenuEntries(net.runelite.api.MenuEntry[] arrmenuEntry) {" +
+						"int n2 = 0;" +
+						"String[] arrstring = this.getMenuOptions();" +
 							"String[] arrstring2 = this.getMenuTargets();" +
 							"int[] arrn = this.getMenuIdentifiers();" +
 							"int[] arrn2 = this.getMenuTypes();" +
@@ -243,270 +232,268 @@ public class ClientTransform implements Transform {
 						"}"
 					, ct);
 			ct.addMethod(setMenuEntries);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
 	}
 
-	public void transformOnMenuOptionsChanged() {
+	private void transformOnMenuOptionsChanged() throws CannotCompileException, NotFoundException
+	{
 		CtMethod onMenuOptionsChanged;
-		try {
-			onMenuOptionsChanged = ct.getDeclaredMethod("onMenuOptionsChanged", new CtClass[]{CtClass.intType});
-			ct.removeMethod(onMenuOptionsChanged);
-			onMenuOptionsChanged = CtMethod.make("	public static void onMenuOptionsChanged(int n2) {"+
-					"										int n3;" +
-					"										int n4 = oldMenuEntryCount;"+
-					"										oldMenuEntryCount = n3 = "+ByteCodePatcher.clientInstance+".getMenuOptionCount();"+
-					"										if (n3 != n4 + 1) return;"+
-					"										net.runelite.api.events.MenuEntryAdded menuEntryAdded = new net.runelite.api.events.MenuEntryAdded("+ByteCodePatcher.clientInstance+".getMenuOptions()[n3 - 1], "+ByteCodePatcher.clientInstance+".getMenuTargets()[n3 - 1], "+ByteCodePatcher.clientInstance+".getMenuTypes()[n3 - 1], "+ByteCodePatcher.clientInstance+".getMenuIdentifiers()[n3 - 1], "+ByteCodePatcher.clientInstance+".getMenuActionParams0()[n3 - 1], "+ByteCodePatcher.clientInstance+".getMenuActionParams1()[n3 - 1]);"+
-					"										"+ByteCodePatcher.clientInstance+".getCallbacks().post((Object)menuEntryAdded);" +
-							"							}"
-														, ct);
+
+		onMenuOptionsChanged = ct.getDeclaredMethod("onMenuOptionsChanged", new CtClass[]{CtClass.intType});
+		ct.removeMethod(onMenuOptionsChanged);
+
+		onMenuOptionsChanged = CtMethod.make(
+			"public static void onMenuOptionsChanged(int n2) {"+
+				"int n3;" +
+				"int n4 = oldMenuEntryCount;"+
+				"oldMenuEntryCount = n3 = "+ByteCodePatcher.clientInstance+".getMenuOptionCount();"+
+				"if (n3 != n4 + 1) return;"+
+					"net.runelite.api.events.MenuEntryAdded menuEntryAdded = new net.runelite.api.events.MenuEntryAdded("+
+						ByteCodePatcher.clientInstance+".getMenuOptions()[n3 - 1],"+
+						ByteCodePatcher.clientInstance+".getMenuTargets()[n3 - 1],"+
+						ByteCodePatcher.clientInstance+".getMenuTypes()[n3 - 1],"+
+						ByteCodePatcher.clientInstance+".getMenuIdentifiers()[n3 - 1],"+
+						ByteCodePatcher.clientInstance+".getMenuActionParams0()[n3 - 1],"+
+						ByteCodePatcher.clientInstance+".getMenuActionParams1()[n3 - 1]);"+
+					ByteCodePatcher.clientInstance+".getCallbacks().post((Object)menuEntryAdded);"+
+				"}"
+			, ct);
+
 			ct.addMethod(onMenuOptionsChanged);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
 	}
 
-	public void transformRenderSelf() {
+	private void transformRenderSelf() throws CannotCompileException
+	{
 		CtMethod renderSelf;
-		try {
-			renderSelf = CtMethod.make("	public void toggleRenderSelf() {"+
-							"						jb = !jb;"+
-							"					}"
-					, ct);
-			ClassFile classFile = ct.getClassFile();
-			ConstPool constPool = classFile.getConstPool();
-			AnnotationsAttribute attr = new AnnotationsAttribute(constPool, AnnotationsAttribute.visibleTag);
-			javassist.bytecode.annotation.Annotation annotation = new javassist.bytecode.annotation.Annotation("Export", constPool);
-			attr.setAnnotation(annotation);
-			renderSelf.getMethodInfo().addAttribute(attr);
-			ct.addMethod(renderSelf);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		renderSelf = CtMethod.make("public void toggleRenderSelf() { jb = !jb; }", ct);
+
+		ClassFile classFile = ct.getClassFile();
+		ConstPool constPool = classFile.getConstPool();
+		AnnotationsAttribute attr = new AnnotationsAttribute(constPool, AnnotationsAttribute.visibleTag);
+		javassist.bytecode.annotation.Annotation annotation = new javassist.bytecode.annotation.Annotation("Export", constPool);
+		attr.setAnnotation(annotation);
+		renderSelf.getMethodInfo().addAttribute(attr);
+
+		ct.addMethod(renderSelf);
 	}
 
-	public void transformDraw2010Menu() {
+	private void transformDraw2010Menu() throws CannotCompileException, NotFoundException
+	{
 		CtMethod draw2010Menu;
-		try {
-			draw2010Menu = ct.getDeclaredMethod("draw2010Menu");
-			ct.removeMethod(draw2010Menu);
-			draw2010Menu = CtNewMethod.make(
-					"    public void draw2010Menu() {" +
-							"        int n2 = this.getMenuX();" +
-							"        int n3 = this.getMenuY();" +
-							"        int n4 = this.getMenuWidth();" +
-							"        int n5 = this.getMenuHeight();" +
-							"        this.RasterizerDrawHorizontalLine(n2 + 2, n3, n4 - 4, 7170651);" +
-							"        this.RasterizerDrawHorizontalLine(n2 + 2, n3 + n5 - 1, n4 - 4, 7170651);" +
-							"        this.RasterizerDrawVerticalLine(n2, n3 + 2, n5 - 4, 7170651);" +
-							"        this.RasterizerDrawVerticalLine(n2 + n4 - 1, n3 + 2, n5 - 4, 7170651);" +
-							"        this.RasterizerDrawRectangle(n2 + 1, n3 + 5, n4 - 2, n5 - 6, 2827810);" +
-							"        this.RasterizerDrawHorizontalLine(n2 + 1, n3 + 17, n4 - 2, 2827810);" +
-							"        this.RasterizerDrawCircle(n2 + 2, n3 + n5 - 3, 0, 2827810);" +
-							"        this.RasterizerDrawCircle(n2 + n4 - 3, n3 + n5 - 3, 0, 2827810);" +
-							"        this.RasterizerDrawGradient(n2 + 2, n3 + 1, n4 - 4, 16, 3288610, 592388);" +
-							"        this.RasterizerFillRectangle(n2 + 1, n3 + 1, 2, 4, 2827810);" +
-							"        this.RasterizerFillRectangle(n2 + n4 - 3, n3 + 1, 2, 4, 2827810);" +
-							"        this.RasterizerDrawHorizontalLine(n2 + 2, n3 + 18, n4 - 4, 5392957);" +
-							"        this.RasterizerDrawHorizontalLine(n2 + 3, n3 + n5 - 3, n4 - 6, 5392957);" +
-							"        this.RasterizerDrawVerticalLine(n2 + 2, n3 + 18, n5 - 21, 5392957);" +
-							"        this.RasterizerDrawVerticalLine(n2 + n4 - 3, n3 + 18, n5 - 21, 5392957);" +
-							"        this.RasterizerFillRectangle(n2 + 3, n3 + 19, n4 - 6, n5 - 22, 2828060);" +
-							"        this.RasterizerDrawCircle(n2 + 1, n3 + 1, 0, 7170651);" +
-							"        this.RasterizerDrawCircle(n2 + n4 - 2, n3 + 1, 0, 7170651);" +
-							"        this.RasterizerDrawCircle(n2 + 1, n3 + n5 - 2, 0, 7170651);" +
-							"        this.RasterizerDrawCircle(n2 + n4 - 2, n3 + n5 - 2, 0, 7170651);" +
-							"        net.runelite.rs.api.RSFont rSFont = this.getFontBold12();" +
-							"        rSFont.drawTextLeftAligned(\"Choose Option\", n2 + 3, n3 + 14, 13023381, -1);" +
-							"        int n6 = this.getMouseX();" +
-							"        int n7 = this.getMouseY();" +
-							"        int n8 = this.getMenuOptionCount();" +
-							"        String[] arrstring = this.getMenuTargets();" +
-							"        String[] arrstring2 = this.getMenuOptions();" +
-							"        for (int i = 0; i < n8; ++i) {" +
-							"            int n9 = n3 + (n8 - 1 - i) * 15 + 31;" +
-							"            String string = arrstring2[i];" +
-							"            if (!arrstring[i].isEmpty()) {" +
-							"                string = string + \" \" + arrstring[i];" +
-							"            }" +
-							"            rSFont.drawTextLeftAligned(string, n2 + 3, n9, 13023381, -1);" +
-							"            if (n6 <= n2 || n6 >= n4 + n2 || n7 <= n9 - 13 || n7 >= n9 + 3) continue;" +
-							"            this.RasterizerFillRectangleAlpha(n2 + 3, n9 - 12, n4 - 6, 15, 16777215, 80);" +
-							"        }" +
-							"    }"
-					, ct);
-			ct.addMethod(draw2010Menu);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		draw2010Menu = ct.getDeclaredMethod("draw2010Menu");
+		ct.removeMethod(draw2010Menu);
+
+		draw2010Menu = CtNewMethod.make(
+			"public void draw2010Menu() {" +
+				"int n2 = this.getMenuX();" +
+				"int n3 = this.getMenuY();" +
+				"int n4 = this.getMenuWidth();" +
+				"int n5 = this.getMenuHeight();" +
+				"this.RasterizerDrawHorizontalLine(n2 + 2, n3, n4 - 4, 7170651);" +
+				"this.RasterizerDrawHorizontalLine(n2 + 2, n3 + n5 - 1, n4 - 4, 7170651);" +
+				"this.RasterizerDrawVerticalLine(n2, n3 + 2, n5 - 4, 7170651);" +
+				"this.RasterizerDrawVerticalLine(n2 + n4 - 1, n3 + 2, n5 - 4, 7170651);" +
+				"this.RasterizerDrawRectangle(n2 + 1, n3 + 5, n4 - 2, n5 - 6, 2827810);" +
+				"this.RasterizerDrawHorizontalLine(n2 + 1, n3 + 17, n4 - 2, 2827810);" +
+				"this.RasterizerDrawCircle(n2 + 2, n3 + n5 - 3, 0, 2827810);" +
+				"this.RasterizerDrawCircle(n2 + n4 - 3, n3 + n5 - 3, 0, 2827810);" +
+				"this.RasterizerDrawGradient(n2 + 2, n3 + 1, n4 - 4, 16, 3288610, 592388);" +
+				"this.RasterizerFillRectangle(n2 + 1, n3 + 1, 2, 4, 2827810);" +
+				"this.RasterizerFillRectangle(n2 + n4 - 3, n3 + 1, 2, 4, 2827810);" +
+				"this.RasterizerDrawHorizontalLine(n2 + 2, n3 + 18, n4 - 4, 5392957);" +
+				"this.RasterizerDrawHorizontalLine(n2 + 3, n3 + n5 - 3, n4 - 6, 5392957);" +
+				"this.RasterizerDrawVerticalLine(n2 + 2, n3 + 18, n5 - 21, 5392957);" +
+				"this.RasterizerDrawVerticalLine(n2 + n4 - 3, n3 + 18, n5 - 21, 5392957);" +
+				"this.RasterizerFillRectangle(n2 + 3, n3 + 19, n4 - 6, n5 - 22, 2828060);" +
+				"this.RasterizerDrawCircle(n2 + 1, n3 + 1, 0, 7170651);" +
+				"this.RasterizerDrawCircle(n2 + n4 - 2, n3 + 1, 0, 7170651);" +
+				"this.RasterizerDrawCircle(n2 + 1, n3 + n5 - 2, 0, 7170651);" +
+				"this.RasterizerDrawCircle(n2 + n4 - 2, n3 + n5 - 2, 0, 7170651);" +
+				"net.runelite.rs.api.RSFont rSFont = this.getFontBold12();" +
+				"rSFont.drawTextLeftAligned(\"Choose Option\", n2 + 3, n3 + 14, 13023381, -1);" +
+				"int n6 = this.getMouseX();" +
+				"int n7 = this.getMouseY();" +
+				"int n8 = this.getMenuOptionCount();" +
+				"String[] arrstring = this.getMenuTargets();" +
+					"String[] arrstring2 = this.getMenuOptions();" +
+					"for (int i = 0; i < n8; ++i) {" +
+						"int n9 = n3 + (n8 - 1 - i) * 15 + 31;" +
+						"String string = arrstring2[i];" +
+						"if (!arrstring[i].isEmpty()) {" +
+							"string = string + \" \" + arrstring[i];" +
+						"}" +
+						"rSFont.drawTextLeftAligned(string, n2 + 3, n9, 13023381, -1);" +
+						"if (n6 <= n2 || n6 >= n4 + n2 || n7 <= n9 - 13 || n7 >= n9 + 3) continue;" +
+						"this.RasterizerFillRectangleAlpha(n2 + 3, n9 - 12, n4 - 6, 15, 16777215, 80);" +
+					"}" +
+				"}"
+			, ct);
+		ct.addMethod(draw2010Menu);
 	}
 
 	//TODO: fix not being able to click far away objects towards top of screen only.
-	public void transformboundingBoxCheck() {
+	private void transformboundingBoxCheck() throws CannotCompileException
+	{
 		CtMethod boundingboxCheck2;
-		try {
-			boundingboxCheck2 = CtMethod.make("    public boolean boundingboxCheck2(net.runelite.api.Model model, int n2, int n3, int n4) {" +
-					"        int n5 = "+ByteCodePatcher.clientInstance+".getCameraPitch();" +
-					"        int n6 = "+ByteCodePatcher.clientInstance+".getCameraYaw();" +
-					"        int n7 = net.runelite.api.Perspective.SINE[n5];" +
-					"        int n8 = net.runelite.api.Perspective.COSINE[n5];" +
-					"        int n9 = net.runelite.api.Perspective.SINE[n6];" +
-					"        int n10 = net.runelite.api.Perspective.COSINE[n6];" +
-					"        int n11 = "+ByteCodePatcher.clientInstance+".getCenterX();" +
-					"        int n12 = "+ByteCodePatcher.clientInstance+".getCenterY();" +
-					"        int n13 = "+ByteCodePatcher.clientInstance+".getViewportMouseX();" +
-					"        int n14 = "+ByteCodePatcher.clientInstance+".getViewportMouseY();" +
-					"        int n15 = "+ByteCodePatcher.clientInstance+".get3dZoom();" +
-					"        int n16 = (n13 - n11) * 50 / n15;" +
-					"        int n17 = (n14 - n12) * 50 / n15;" +
-					"        int n18 = (n13 - n11) * 10000 / n15;" +
-					"        int n19 = (n14 - n12) * 10000 / n15;" +
-					"        int n20 = client.rl$rot1(n17, 50, n8, n7);" +
-					"        int n21 = client.rl$rot2(n17, 50, n8, n7);" +
-					"        n17 = n20;" +
-					"        n20 = client.rl$rot1(n19, 10000, n8, n7);" +
-					"        int n22 = client.rl$rot2(n19, 10000, n8, n7);" +
-					"        n19 = n20;" +
-					"        n20 = client.rl$rot3(n16, n21, n10, n9);" +
-					"        n21 = client.rl$rot4(n16, n21, n10, n9);" +
-					"        n16 = n20;" +
-					"        n20 = client.rl$rot3(n18, n22, n10, n9);" +
-					"        n22 = client.rl$rot4(n18, n22, n10, n9);" +
-					"        int n23 = (n20 - n16) / 2;" +
-					"        int n24 = (n19 - n17) / 2;" +
-					"        int n25 = (n22 - n21) / 2;" +
-					"        int n26 = Math.abs(n23);" +
-					"        int n27 = Math.abs(n24);" +
-					"        int n28 = Math.abs(n25);" +
-					"        int n29 = n2 + model.getCenterX();" +
-					"        int n30 = n3 + model.getCenterY();" +
-					"        int n31 = n4 + model.getCenterZ();" +
-					"        int n32 = model.getExtremeX();" +
-					"        int n33 = model.getExtremeY();" +
-					"        int n34 = model.getExtremeZ();" +
-					"        int n35 = (n16 + n20) / 2;" +
-					"        int n36 = (n17 + n19) / 2;" +
-					"        int n37 = (n22 + n21) / 2;" +
-					"        int n38 = n35 - n29;" +
-					"        int n39 = n36 - n30;" +
-					"        int n40 = n37 - n31;" +
-					"        if (Math.abs(n38) > n32 + n26) {" +
-					"            return false;" +
-					"        }" +
-					"        if (Math.abs(n39) > n33 + n27) {" +
-					"            return false;" +
-					"        }" +
-					"        if (Math.abs(n40) > n34 + n28) {" +
-					"            return false;" +
-					"        }" +
-					"        if (Math.abs(n40 * n24 - n39 * n25) > n33 * n28 + n34 * n27) {" +
-					"            return false;" +
-					"        }" +
-					"        if (Math.abs(n38 * n25 - n40 * n23) > n34 * n26 + n32 * n28) {" +
-					"            return false;" +
-					"        }" +
-					"        if (Math.abs(n39 * n23 - n38 * n24) <= n33 * n26 + n32 * n27) return true;" +
-					"        return false;" +
-					"    }", ct);
-			ct.addMethod(boundingboxCheck2);
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
+
+		boundingboxCheck2 = CtMethod.make(
+			"public boolean boundingboxCheck2(net.runelite.api.Model model, int n2, int n3, int n4) {" +
+				"int n5 = "+ByteCodePatcher.clientInstance+".getCameraPitch();" +
+				"int n6 = "+ByteCodePatcher.clientInstance+".getCameraYaw();" +
+				"int n7 = net.runelite.api.Perspective.SINE[n5];" +
+				"int n8 = net.runelite.api.Perspective.COSINE[n5];" +
+				"int n9 = net.runelite.api.Perspective.SINE[n6];" +
+				"int n10 = net.runelite.api.Perspective.COSINE[n6];" +
+				"int n11 = "+ByteCodePatcher.clientInstance+".getCenterX();" +
+				"int n12 = "+ByteCodePatcher.clientInstance+".getCenterY();" +
+				"int n13 = "+ByteCodePatcher.clientInstance+".getViewportMouseX();" +
+				"int n14 = "+ByteCodePatcher.clientInstance+".getViewportMouseY();" +
+				"int n15 = "+ByteCodePatcher.clientInstance+".get3dZoom();" +
+				"int n16 = (n13 - n11) * 50 / n15;" +
+				"int n17 = (n14 - n12) * 50 / n15;" +
+				"int n18 = (n13 - n11) * 10000 / n15;" +
+				"int n19 = (n14 - n12) * 10000 / n15;" +
+				"int n20 = client.rl$rot1(n17, 50, n8, n7);" +
+				"int n21 = client.rl$rot2(n17, 50, n8, n7);" +
+				"n17 = n20;" +
+				"n20 = client.rl$rot1(n19, 10000, n8, n7);" +
+				"int n22 = client.rl$rot2(n19, 10000, n8, n7);" +
+				"n19 = n20;" +
+				"n20 = client.rl$rot3(n16, n21, n10, n9);" +
+				"n21 = client.rl$rot4(n16, n21, n10, n9);" +
+				"n16 = n20;" +
+				"n20 = client.rl$rot3(n18, n22, n10, n9);" +
+				"n22 = client.rl$rot4(n18, n22, n10, n9);" +
+				"int n23 = (n20 - n16) / 2;" +
+				"int n24 = (n19 - n17) / 2;" +
+				"int n25 = (n22 - n21) / 2;" +
+				"int n26 = Math.abs(n23);" +
+				"int n27 = Math.abs(n24);" +
+				"int n28 = Math.abs(n25);" +
+				"int n29 = n2 + model.getCenterX();" +
+				"int n30 = n3 + model.getCenterY();" +
+				"int n31 = n4 + model.getCenterZ();" +
+				"int n32 = model.getExtremeX();" +
+				"int n33 = model.getExtremeY();" +
+				"int n34 = model.getExtremeZ();" +
+				"int n35 = (n16 + n20) / 2;" +
+				"int n36 = (n17 + n19) / 2;" +
+				"int n37 = (n22 + n21) / 2;" +
+				"int n38 = n35 - n29;" +
+				"int n39 = n36 - n30;" +
+				"int n40 = n37 - n31;" +
+				"if (Math.abs(n38) > n32 + n26) {" +
+					"return false;" +
+				"}" +
+				"if (Math.abs(n39) > n33 + n27) {" +
+					"return false;" +
+				"}" +
+				"if (Math.abs(n40) > n34 + n28) {" +
+					"return false;" +
+				"}" +
+				"if (Math.abs(n40 * n24 - n39 * n25) > n33 * n28 + n34 * n27) {" +
+					"return false;" +
+				"}" +
+				"if (Math.abs(n38 * n25 - n40 * n23) > n34 * n26 + n32 * n28) {" +
+					"return false;" +
+				"}" +
+				"if (Math.abs(n39 * n23 - n38 * n24) <= n33 * n26 + n32 * n27) return true;" +
+				"return false;" +
+			"}", ct);
+		ct.addMethod(boundingboxCheck2);
 	}
 
-		public void transformcheckClickBox() {
-			CtMethod checkClickBox;
-			try {
-				checkClickBox = ct.getDeclaredMethod("checkClickbox");
-				ct.removeMethod(checkClickBox);
-				checkClickBox = CtMethod.make("public void checkClickbox(net.runelite.api.Model model, int n2, int n3, int n4, int n5, int n6, int n7, int n8, int n9, long l2) {"+
-								"						int n10;" +
-								"        				int n11;" +
-								"        				int n12;" +
-								"        				int n13;" +
-								"        				int n14;" +
-								"						net.runelite.rs.api.RSModel rSModel = (net.runelite.rs.api.RSModel)model;" +
-								"        				boolean bl2 = l2 != 0L && (int)(l2 >>> 16 & 1L) != 1;" +
-								"        				boolean bl3 = "+ByteCodePatcher.clientInstance+".getViewportContainsMouse();" +
-								"        				if (!bl2) return;" +
-								"        					if (!bl3) return;" +
-								"        					boolean bl4 = this.boundingboxCheck2((net.runelite.api.Model)rSModel, n7, n8, n9);" +
-								"        					if (!bl4) {" +
-								"            					return;" +
-								"        					}" +
-								"        					if (rSModel.isClickable()) {" +
-								"            					this.addHashAtMouse(l2);" +
-								"            					return;" +
-								"        					}" +
-								"        					int n15 = rSModel.getVerticesCount();" +
-								"        					int n16 = rSModel.getTrianglesCount();" +
-								"        					int[] arrn = rSModel.getVerticesX();" +
-								"        					int[] arrn2 = rSModel.getVerticesY();" +
-								"        					int[] arrn3 = rSModel.getVerticesZ();" +
-								"        					int[] arrn4 = rSModel.getTrianglesX();" +
-								"        					int[] arrn5 = rSModel.getTrianglesY();" +
-								"        					int[] arrn6 = rSModel.getTrianglesZ();" +
-								"        					int[] arrn7 = rSModel.getFaceColors3();" +
-								"        					int n17 = "+ByteCodePatcher.clientInstance+".get3dZoom();" +
-								"        					int n18 = "+ByteCodePatcher.clientInstance+".getCenterX();" +
-								"        					int n19 = "+ByteCodePatcher.clientInstance+".getCenterY();" +
-								"        					int n20 = 0;" +
-								"        					int n21 = 0;" +
-								"        					if (n2 != 0) {" +
-								"           					n20 = net.runelite.api.Perspective.SINE[n2];" +
-								"            					n21 = net.runelite.api.Perspective.COSINE[n2];" +
-								"        					}" +
-								"        					for (n14 = 0; n14 < n15; ++n14) {" +
-								"            					n11 = arrn[n14];" +
-								"            					n13 = arrn2[n14];" +
-								"            					n12 = arrn3[n14];" +
-								"            					if (n2 != 0) {" +
-								"               					n10 = n12 * n20 + n11 * n21 >> 16;" +
-								"               					n12 = n12 * n21 - n11 * n20 >> 16;" +
-								"                					n11 = n10;" +
-								"            					}" +
-								"            					n10 = (n12 += n9) * n5 + n6 * (n11 += n7) >> 16;" +
-								"            					n12 = n6 * n12 - n11 * n5 >> 16;" +
-								"            					n11 = n10;" +
-								"            					n10 = n4 * (n13 += n8) - n12 * n3 >> 16;" +
-								"            					if ((n12 = n13 * n3 + n4 * n12 >> 16) >= 50) {" +
-								"                					client.rl$modelViewportYs[n14] = n11 * n17 / n12 + n18;" +
-								"                					client.rl$modelViewportXs[n14] = n10 * n17 / n12 + n19;" +
-								"                					continue;" +
-								"            					}" +
-								"            					client.rl$modelViewportYs[n14] = -5000;" +
-								"        					}" +
-								"        					n14 = "+ByteCodePatcher.clientInstance+".getViewportMouseX();" +
-								"        					n11 = "+ByteCodePatcher.clientInstance+".getViewportMouseY();" +
-								"        					n13 = 0;" +
-								"        					while (n13 < n16) {" +
-								"            					if (arrn7[n13] != -2) {" +
-								"                					int n22;" +
-								"                					boolean bl5;" +
-								"                					int n23;" +
-								"                					n12 = arrn4[n13];" +
-								"                					n10 = arrn5[n13];" +
-								"                					int n24 = arrn6[n13];" +
-								"                					int n25 = rl$modelViewportYs[n12];" +
-								"                					int n26 = rl$modelViewportYs[n10];" +
-								"                					int n27 = rl$modelViewportYs[n24];" +
-								"                					int n28 = rl$modelViewportXs[n12];" +
-								"                					int n29 = rl$modelViewportXs[n10];" +
-								"                					int n30 = rl$modelViewportXs[n24];" +
-								"                					if (n25 != -5000 && n26 != -5000 && n27 != -5000 && (bl5 = (n23 = (n22 = rSModel.isClickable() ? 20 : 5) + n11) < n28 && n23 < n29 && n23 < n30 ? false : ((n23 = n11 - n22) > n28 && n23 > n29 && n23 > n30 ? false : ((n23 = n22 + n14) < n25 && n23 < n26 && n23 < n27 ? false : (n23 = n14 - n22) <= n25 || n23 <= n26 || n23 <= n27)))) {" +
-								"                    					this.addHashAtMouse(l2);" +
-								"                    					return;" +
-								"                					}" +
-								"            					}" +
-								"            					++n13;" +
-								"        					}" +
-								"    					}"
-						, ct);
-				ct.addMethod(checkClickBox);
-			} catch (Exception e) {
-				e.printStackTrace();
-			}
-		}
+	private void transformcheckClickBox() throws CannotCompileException, NotFoundException
+	{
+		CtMethod checkClickBox;
+
+		checkClickBox = ct.getDeclaredMethod("checkClickbox");
+		ct.removeMethod(checkClickBox);
+
+		checkClickBox = CtMethod.make(
+			"public void checkClickbox(net.runelite.api.Model model, int n2, int n3, int n4, int n5, int n6, int n7, int n8, int n9, long l2) {"+
+				"int n10;" +
+				"int n11;" +
+				"int n12;" +
+				"int n13;" +
+				"int n14;" +
+				"net.runelite.rs.api.RSModel rSModel = (net.runelite.rs.api.RSModel)model;" +
+				"boolean bl2 = l2 != 0L && (int)(l2 >>> 16 & 1L) != 1;" +
+				"boolean bl3 = "+ByteCodePatcher.clientInstance+".getViewportContainsMouse();" +
+				"if (!bl2) return;" +
+				"if (!bl3) return;" +
+				"boolean bl4 = this.boundingboxCheck2((net.runelite.api.Model)rSModel, n7, n8, n9);" +
+				"if (!bl4) {" +
+					"return;" +
+				"}" +
+				"if (rSModel.isClickable()) {" +
+					"this.addHashAtMouse(l2);" +
+					"return;" +
+				"}" +
+				"int n15 = rSModel.getVerticesCount();" +
+				"int n16 = rSModel.getTrianglesCount();" +
+				"int[] arrn = rSModel.getVerticesX();" +
+				"int[] arrn2 = rSModel.getVerticesY();" +
+				"int[] arrn3 = rSModel.getVerticesZ();" +
+				"int[] arrn4 = rSModel.getTrianglesX();" +
+				"int[] arrn5 = rSModel.getTrianglesY();" +
+				"int[] arrn6 = rSModel.getTrianglesZ();" +
+				"int[] arrn7 = rSModel.getFaceColors3();" +
+				"int n17 = "+ByteCodePatcher.clientInstance+".get3dZoom();" +
+				"int n18 = "+ByteCodePatcher.clientInstance+".getCenterX();" +
+				"int n19 = "+ByteCodePatcher.clientInstance+".getCenterY();" +
+				"int n20 = 0;" +
+				"int n21 = 0;" +
+				"if (n2 != 0) {" +
+					"n20 = net.runelite.api.Perspective.SINE[n2];" +
+					"n21 = net.runelite.api.Perspective.COSINE[n2];" +
+				"}" +
+				"for (n14 = 0; n14 < n15; ++n14) {" +
+					"n11 = arrn[n14];" +
+					"n13 = arrn2[n14];" +
+					"n12 = arrn3[n14];" +
+					"if (n2 != 0) {" +
+						"n10 = n12 * n20 + n11 * n21 >> 16;" +
+						"n12 = n12 * n21 - n11 * n20 >> 16;" +
+						"n11 = n10;" +
+					"}" +
+					"n10 = (n12 += n9) * n5 + n6 * (n11 += n7) >> 16;" +
+					"n12 = n6 * n12 - n11 * n5 >> 16;" +
+					"n11 = n10;" +
+					"n10 = n4 * (n13 += n8) - n12 * n3 >> 16;" +
+					"if ((n12 = n13 * n3 + n4 * n12 >> 16) >= 50) {" +
+						"client.rl$modelViewportYs[n14] = n11 * n17 / n12 + n18;" +
+						"client.rl$modelViewportXs[n14] = n10 * n17 / n12 + n19;" +
+						"continue;" +
+					"}" +
+					"client.rl$modelViewportYs[n14] = -5000;" +
+				"}" +
+				"n14 = "+ByteCodePatcher.clientInstance+".getViewportMouseX();" +
+				"n11 = "+ByteCodePatcher.clientInstance+".getViewportMouseY();" +
+				"n13 = 0;" +
+				"while (n13 < n16) {" +
+					"if (arrn7[n13] != -2) {" +
+						"int n22;" +
+						"boolean bl5;" +
+						"int n23;" +
+						"n12 = arrn4[n13];" +
+						"n10 = arrn5[n13];" +
+						"int n24 = arrn6[n13];" +
+						"int n25 = rl$modelViewportYs[n12];" +
+						"int n26 = rl$modelViewportYs[n10];" +
+						"int n27 = rl$modelViewportYs[n24];" +
+						"int n28 = rl$modelViewportXs[n12];" +
+						"int n29 = rl$modelViewportXs[n10];" +
+						"int n30 = rl$modelViewportXs[n24];" +
+						"if (n25 != -5000 && n26 != -5000 && n27 != -5000 && (bl5 = (n23 = (n22 = rSModel.isClickable() ? 20 : 5) + n11) < n28 && n23 < n29 && n23 < n30 ? false : ((n23 = n11 - n22) > n28 && n23 > n29 && n23 > n30 ? false : ((n23 = n22 + n14) < n25 && n23 < n26 && n23 < n27 ? false : (n23 = n14 - n22) <= n25 || n23 <= n26 || n23 <= n27)))) {" +
+							"this.addHashAtMouse(l2);" +
+							"return;" +
+						"}" +
+					"}" +
+					"++n13;" +
+				"}" +
+			"}", ct);
+			ct.addMethod(checkClickBox);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ErrorTransform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ErrorTransform.java
@@ -1,39 +1,43 @@
 package net.runelite.client.rs.bytecode.transformers;
 
+import javassist.CannotCompileException;
 import javassist.CtClass;
 import javassist.CtMethod;
-import javassist.CtNewMethod;
+import javassist.NotFoundException;
 import net.runelite.client.rs.bytecode.ByteCodePatcher;
 
 //This prevents the client from sending stack traces to Jagex at all, even classes outside of runelite.
 public class ErrorTransform implements Transform {
-    public CtClass ct = null;
+	private CtClass ct;
 
-    //Where Runelites error interceptor is located, not auto-scraped.
-    private final String ERROR_INSTANCE_CLASS = "dp";
-    private final String ERROR_INSTANCE_METHOD = "a";
-    private final String ERROR_WARNING = "Tried to send a warning";
+	//Where Runelites error interceptor is located, not auto-scraped.
+    private static final String ERROR_INSTANCE_CLASS = "dp";
+    private static final String ERROR_INSTANCE_METHOD = "a";
+    //private static final String ERROR_WARNING = "Tried to send a warning";
 
     @Override
     public void modify(Class clazz) {
         try {
             System.out.println("[RuneLitePlus] Transforming error method at class: "+ERROR_INSTANCE_CLASS);
-            ct = ByteCodePatcher.classPool.get(ERROR_INSTANCE_CLASS);
-            CtMethod error = ct.getDeclaredMethod(ERROR_INSTANCE_METHOD);
-            ct.removeMethod(error);
-            error = CtMethod.make("public static void a(String string, Throwable throwable, byte by) {"+
-                    "                       throwable.printStackTrace();"+
-                    "                       System.out.println(\"[RuneLitePlus] Prevented preceeding stack trace from being sent to Jagex\");"+
-                    "                   }", ct);
-            ct.addMethod(error);
+
+			ct = ByteCodePatcher.classPool.get(ERROR_INSTANCE_CLASS);
+            transformError();
+
             ByteCodePatcher.modifiedClasses.add(ct);
-        } catch (Exception e) {
+        } catch (CannotCompileException | NotFoundException e) {
             e.printStackTrace();
         }
     }
 
-    @Override
-    public void transform() {
+    private void transformError() throws CannotCompileException, NotFoundException
+	{
+		CtMethod error = ct.getDeclaredMethod(ERROR_INSTANCE_METHOD);
+		ct.removeMethod(error);
 
-    }
+		error = CtMethod.make(
+			"public static void a(String string, Throwable throwable, byte by) {"+
+				"throwable.printStackTrace();"+
+				"System.out.println(\"[RuneLitePlus] Prevented preceeding stack trace from being sent to Jagex\");}", ct);
+		ct.addMethod(error);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/PlayerTransform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/PlayerTransform.java
@@ -1,12 +1,14 @@
 package net.runelite.client.rs.bytecode.transformers;
 
+import javassist.CannotCompileException;
 import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.CtNewMethod;
+import javassist.NotFoundException;
 import net.runelite.client.rs.bytecode.ByteCodePatcher;
 
 public class PlayerTransform implements Transform {
-    public CtClass ct = null;
+	private CtClass ct;
 
     @Override
     public void modify(Class player) {
@@ -15,53 +17,47 @@ public class PlayerTransform implements Transform {
             transformProtectedGetSkullIcon();
             transformGetSkullIcon();
             ByteCodePatcher.modifiedClasses.add(ct);
-        } catch (Exception e) {
+        } catch (CannotCompileException | NotFoundException e) {
             e.printStackTrace();
         }
     }
 
-    @Override
-    public void transform(){}
-
-    public void transformProtectedGetSkullIcon() {
+    private void transformProtectedGetSkullIcon() throws CannotCompileException, NotFoundException {
         CtMethod protectedGetSkullIcon;
-        try {
-            protectedGetSkullIcon = ct.getDeclaredMethod("1protect$getRsSkullIcon");
-            ct.removeMethod(protectedGetSkullIcon);
-            protectedGetSkullIcon.setName("getRsSkullIcon");
-            ct.addMethod(protectedGetSkullIcon);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
 
+        protectedGetSkullIcon = ct.getDeclaredMethod("1protect$getRsSkullIcon");
+        ct.removeMethod(protectedGetSkullIcon);
+        protectedGetSkullIcon.setName("getRsSkullIcon");
+
+        ct.addMethod(protectedGetSkullIcon);
     }
 
-    public void transformGetSkullIcon() {
+    private void transformGetSkullIcon() throws CannotCompileException, NotFoundException
+	{
         CtMethod getSkullIcon;
-        try {
-            String SkullIcon = "net.runelite.api.SkullIcon";
-            getSkullIcon = ct.getDeclaredMethod("getSkullIcon");
-            ct.removeMethod(getSkullIcon);
-            getSkullIcon = CtNewMethod.make("public "+SkullIcon+" getSkullIcon() {" +
-                    "                               switch (this.getRsSkullIcon()) {" +
-                    "                               case 0: {" +
-                    "                               return "+SkullIcon+".SKULL; }" +
-                    "                               case 1: {" +
-                    "                               return "+SkullIcon+".SKULL_FIGHT_PIT; }" +
-                    "                               case 8: {" +
-                    "                               return "+SkullIcon+".DEAD_MAN_FIVE; }" +
-                    "                               case 9: {" +
-                    "                               return "+SkullIcon+".DEAD_MAN_FOUR; }" +
-                    "                               case 10: {" +
-                    "                               return "+SkullIcon+".DEAD_MAN_THREE; }" +
-                    "                               case 11: {" +
-                    "                               return "+SkullIcon+".DEAD_MAN_TWO; }" +
-                    "                               case 12: {" +
-                    "                               return "+SkullIcon+".DEAD_MAN_ONE; } }" +
-                    "                               return null; }",ct);
-            ct.addMethod(getSkullIcon);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
+
+        String SkullIcon = "net.runelite.api.SkullIcon";
+        getSkullIcon = ct.getDeclaredMethod("getSkullIcon");
+        ct.removeMethod(getSkullIcon);
+
+        getSkullIcon = CtNewMethod.make(
+        	"public "+SkullIcon+" getSkullIcon() {" +
+				"switch (this.getRsSkullIcon()) {" +
+					"case 0: {" +
+						"return " + SkullIcon + ".SKULL; }" +
+					"case 1: {" +
+						"return " + SkullIcon + ".SKULL_FIGHT_PIT; }" +
+					"case 8: {" +
+						"return " + SkullIcon + ".DEAD_MAN_FIVE; }" +
+					"case 9: {" +
+						"return " + SkullIcon + ".DEAD_MAN_FOUR; }" +
+					"case 10: {" +
+						"return " + SkullIcon + ".DEAD_MAN_THREE; }" +
+					"case 11: {" +
+						"return " + SkullIcon + ".DEAD_MAN_TWO; }" +
+					"case 12: {" +
+						"return " + SkullIcon + ".DEAD_MAN_ONE; } }" +
+				"return null; }", ct);
+        ct.addMethod(getSkullIcon);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ProjectileTransform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/ProjectileTransform.java
@@ -1,42 +1,80 @@
 package net.runelite.client.rs.bytecode.transformers;
 
+import javassist.CannotCompileException;
 import javassist.CtClass;
 import javassist.CtMethod;
 import javassist.CtNewMethod;
+import javassist.NotFoundException;
 import net.runelite.client.rs.bytecode.ByteCodePatcher;
 
 public class ProjectileTransform implements Transform {
-    public CtClass ct = null;
+	private CtClass ct;
+
+	// Next variable is manually added, and will break on rev update
+	private static final String interactingIntvalue = "-1655053057";
 
     @Override
     public void modify(Class projectile) {
-        try {
+        try
+		{
             ct = ByteCodePatcher.classPool.get(projectile.getName());
-            transform();
+
+            transformGetAnimation();
+
+            transformInteracting();
+
             ByteCodePatcher.modifiedClasses.add(ct);
-        } catch (Exception e) {
+        }
+        catch (CannotCompileException | NotFoundException e) {
             e.printStackTrace();
         }
     }
 
-    @Override
-    public void transform() {
+	private void transformGetAnimation() throws CannotCompileException, NotFoundException
+	{
         CtMethod getAnimation;
-        try {
-            getAnimation = ct.getDeclaredMethod("projectileMoved", new CtClass[]{CtClass.intType, CtClass.intType, CtClass.intType, CtClass.intType});
-            ct.removeMethod(getAnimation);
-            getAnimation = CtNewMethod.make("public void projectileMoved(int n, int n2, int n3, int n4) { " +
-                    "                               int n5 = this.getId();" +
-                    "                               net.runelite.api.coords.LocalPoint localPoint = new net.runelite.api.coords.LocalPoint(n, n2);" +
-                    "                               net.runelite.api.events.ProjectileMoved projectileMoved = new net.runelite.api.events.ProjectileMoved();" +
-                    "                               projectileMoved.setProjectile(this);" +
-                    "                               projectileMoved.setPosition(localPoint);" +
-                    "                               projectileMoved.setZ(n3);" +
-                    "                               "+ByteCodePatcher.clientInstance+".getCallbacks().post(projectileMoved); }",ct);
-            ct.addMethod(getAnimation);
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
+
+        getAnimation = ct.getDeclaredMethod("projectileMoved", new CtClass[]{CtClass.intType, CtClass.intType, CtClass.intType, CtClass.intType});
+        ct.removeMethod(getAnimation);
+
+        getAnimation = CtNewMethod.make(
+        	"public void projectileMoved(int n, int n2, int n3, int n4) { " +
+                	"int n5 = this.getId();" +
+                	"net.runelite.api.coords.LocalPoint localPoint = new net.runelite.api.coords.LocalPoint(n, n2);" +
+                	"net.runelite.api.events.ProjectileMoved projectileMoved = new net.runelite.api.events.ProjectileMoved();" +
+                	"projectileMoved.setProjectile(this);" +
+                	"projectileMoved.setPosition(localPoint);" +
+                	"projectileMoved.setZ(n3);" +
+                	ByteCodePatcher.clientInstance + ".getCallbacks().post(projectileMoved); }", ct);
+        ct.addMethod(getAnimation);
     }
 
+    private void transformInteracting() throws CannotCompileException
+	{
+		CtMethod getRsInteracting;
+		CtMethod getInteracting;
+
+		getRsInteracting = CtNewMethod.make("public int getRsInteracting() { return this.n * " + interactingIntvalue + "; }", ct);
+		ct.addMethod(getRsInteracting);
+
+		getInteracting = CtNewMethod.make(
+		"public net.runelite.api.Actor getInteracting() {" +
+			"int var1 = this.getRsInteracting();" +
+			"if (var1 == 0) {" +
+				"return null;" +
+			"} else {" +
+				"int var2;" +
+				"if (var1 > 0) {" +
+					"var2 = var1 - 1;" +
+					"net.runelite.rs.api.RSNPC[] var4 = " + ByteCodePatcher.clientInstance + ".getCachedNPCs();" +
+					"return var4[var2];" +
+				"} else {" +
+					"var2 = -var1 - 1;" +
+					"if (var2 == " + ByteCodePatcher.clientInstance + ".getLocalInteractingIndex()) {" +
+						"return " + ByteCodePatcher.clientInstance + ".getLocalPlayer();" +
+					"} else {" +
+						"net.runelite.rs.api.RSPlayer[] var3 = " + ByteCodePatcher.clientInstance + ".getCachedPlayers();" +
+						"return var3[var2]; }}}}", ct);
+		ct.addMethod(getInteracting);
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/Transform.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/bytecode/transformers/Transform.java
@@ -3,6 +3,5 @@ package net.runelite.client.rs.bytecode.transformers;
 public interface Transform {
 
 	void modify(Class clazz);
-	void transform();
 
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSProjectileMixin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.mixins;
 
+import net.runelite.api.Actor;
 import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.events.ProjectileMoved;
 import net.runelite.api.mixins.Inject;
@@ -31,6 +32,8 @@ import net.runelite.api.mixins.MethodHook;
 import net.runelite.api.mixins.Mixin;
 import net.runelite.api.mixins.Shadow;
 import net.runelite.rs.api.RSClient;
+import net.runelite.rs.api.RSNPC;
+import net.runelite.rs.api.RSPlayer;
 import net.runelite.rs.api.RSProjectile;
 
 @Mixin(RSProjectile.class)
@@ -46,6 +49,36 @@ public abstract class RSProjectileMixin implements RSProjectile
 		int currentGameCycle = client.getGameCycle();
 
 		return getEndCycle() - currentGameCycle;
+	}
+
+	@Inject
+	@Override
+	public Actor getInteracting()
+	{
+		int interactingIndex = getRsInteracting();
+		if (interactingIndex == 0)
+		{
+			return null;
+		}
+
+		if (interactingIndex > 0)
+		{
+			int idx = interactingIndex - 1;
+			RSNPC[] npcs = client.getCachedNPCs();
+			return npcs[idx];
+		}
+		else
+		{
+			int idx = -interactingIndex - 1;
+
+			if (idx == client.getLocalInteractingIndex())
+			{
+				return client.getLocalPlayer();
+			}
+
+			RSPlayer[] players = client.getCachedPlayers();
+			return players[idx];
+		}
 	}
 
 	/**

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSProjectile.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSProjectile.java
@@ -33,6 +33,9 @@ public interface RSProjectile extends RSRenderable, Projectile
 	@Override
 	int getId();
 
+	@Import("interacting")
+	int getRsInteracting();
+
 	@Import("height")
 	@Override
 	int getHeight();


### PR DESCRIPTION
I personally think the transforms are a lot more readable like this, and it also makes for a nice format to follow, instead of having 10 slightly different codestyles next to each other and try blocks in every method.

The value in getInteracting has to be updated manually, unless we want to add a deob as a dependency