### PR TITLE
Hydra: Fix a poison special bug

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/alchemicalhydra/HydraPlugin.java
@@ -229,8 +229,12 @@ public class HydraPlugin extends Plugin
 
 		if (hydra.getPhase().getSpecProjectileId() != 0 && hydra.getPhase().getSpecProjectileId() == id)
 		{
-			poisonProjectiles.put(event.getPosition(), projectile);
+			if (poisonProjectiles.isEmpty())
+			{
+				// Only add 9 to next special on the first poison projectile (whoops)
 			hydra.setNextSpecial(hydra.getNextSpecial() + 9);
+		}
+			poisonProjectiles.put(event.getPosition(), projectile);
 		}
 		else if (client.getTickCount() != lastAttackTick
 			&& (id == Hydra.AttackStyle.MAGIC.getProjId() || id == Hydra.AttackStyle.RANGED.getProjId()))


### PR DESCRIPTION
Displays the next poison special indicator with the correct count, even if the last one was with more than 1 poison ball