### PR TITLE
Freeze additions

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeInfo.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeInfo.java
@@ -1,0 +1,15 @@
+package net.runelite.client.plugins.freezetimers;
+
+import lombok.Builder;
+import lombok.Getter;
+import net.runelite.api.Actor;
+import net.runelite.api.coords.LocalPoint;
+
+@Builder
+public class FreezeInfo
+{
+    @Getter
+    private final Actor actor;
+    @Getter
+    private final LocalPoint freezePoint;
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2019, ganom <https://github.com/Ganom>
+ * Copyright (c) 2019, kyle <https://github.com/kyleeld>
  * Copyright (c) 2019, pklite <https://github.com/pklite/pklite>
  * All rights reserved.
  *
@@ -24,6 +25,7 @@
  */
 package net.runelite.client.plugins.freezetimers;
 
+import com.google.common.eventbus.Subscribe;
 import java.awt.Color;
 import static java.awt.Color.RED;
 import static java.awt.Color.WHITE;
@@ -32,10 +34,14 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Polygon;
 import java.awt.image.BufferedImage;
+import java.util.Map;
+import java.util.HashMap;
 import javax.inject.Inject;
 import net.runelite.api.Actor;
 import net.runelite.api.Client;
+import net.runelite.api.events.PlayerDespawned;
 import net.runelite.api.GraphicID;
+import net.runelite.api.Player;
 import net.runelite.api.Point;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.Overlay;
@@ -47,7 +53,7 @@ import net.runelite.client.util.ImageUtil;
 
 public class FreezeTimersOverlay extends Overlay
 {
-
+	private final Map<String, FreezeInfo> freezes = new HashMap<>();
 	private final FreezeTimersConfig config;
 	private final Client client;
 	private final Font timerFont = FontManager.getRunescapeBoldFont().deriveFont(14.0f);
@@ -84,6 +90,22 @@ public class FreezeTimersOverlay extends Overlay
 		return null;
 	}
 
+	@Subscribe
+	public void onPlayerDespawned(PlayerDespawned playerDespawned)
+	{
+		final Player player = playerDespawned.getPlayer();
+		// All despawns ok: death, teleports, log out, runs away from screen
+		if (config.showPlayers() | config.showNpcs() | config.FreezeTimers() | config.Veng() | config.TB())
+		{
+			this.remove(player);
+		}
+
+	}
+
+	public void remove(Actor actor)
+	{
+		freezes.remove(actor.getName());
+	}
 	private void renderOverlayFor(Graphics2D g, Actor actor)
 	{
 		if (timers.areAllTimersZero(actor))


### PR DESCRIPTION
added in player despawns.

a despawn is counted as:

1) player death
2) player teleports
3) player logs out
4) player runs away from screen

upon triggering 1 of the despawns, the timers will remove themselves for accurate refreezing/appearance