### PR TITLE
Maven package upgrades fixing Zip Slip vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.0.0-M1</version>
+				<version>3.1.0</version>
 				<configuration>
 					<!-- Fix Javadoc on Java 11+ - JDK-8212233 -->
 					<source>8</source>

--- a/runelite-script-assembler-plugin/pom.xml
+++ b/runelite-script-assembler-plugin/pom.xml
@@ -65,7 +65,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-plugin-plugin</artifactId>
-				<version>3.4</version>
+				<version>3.6.0</version>
 				<executions>
 					<execution>
 						<id>default-descriptor</id>


### PR DESCRIPTION
Maven package security updates for the [Zip Slip Vulnerability](https://maven.apache.org/security-plexus-archiver.html) in the plexus-archiver package.
[CVE-2018-1002200](https://www.cvedetails.com/cve/CVE-2018-1002200/)

Packages upgrade:

* maven-plugin-plugin from 3.4 to [3.6.0](https://blog.soebes.de/blog/2018/11/01/apache-maven-plugin-tools-version-3-dot-6-0-released/). This upgrade skips [3.5](https://blog.soebes.de/blog/2016/08/31/apache-maven-plugin-tools-version-3-dot-5-released/), [3.5.1](https://blog.soebes.de/blog/2018/01/22/apache-maven-plugin-tools-version-3-dot-5-1-released/) and [3.5.2](https://blog.soebes.de/blog/2018/05/26/apache-mave-plugin-tools-version-3-dot-5-2-released/)(Vulnerability was fixed in 3.5.2)
* maven-javadoc-plugin from 3.0.0-M1 to [3.1.0](https://blog.soebes.de/blog/2019/03/04/apache-maven-javadoc-plugin-version-3-dot-1.0-released/). This upgrade skips [3.0.0](http://mail-archives.apache.org/mod_mbox/maven-announce/201712.mbox/%3Cop.zaufhhzukdkhrr@desktop-2khsk44.mshome.net%3E), [3.0.1](https://blog.soebes.de/blog/2018/05/28/apache-maven-javadoc-plugin-version-3-dot-0-1-released/). (Vulnerability was fixed in 3.0.1)

