### PR TITLE
Add custom menu swaps to menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/AbstractMenuEntry.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/AbstractMenuEntry.java
@@ -6,7 +6,7 @@ import net.runelite.api.MenuEntry;
 import static net.runelite.client.menus.MenuManager.LEVEL_PATTERN;
 import net.runelite.client.util.Text;
 
-class AbstractMenuEntry
+public class AbstractMenuEntry
 {
 	@Getter
 	private String option;
@@ -26,17 +26,17 @@ class AbstractMenuEntry
 	@Getter
 	private boolean strictTarget;
 
-	AbstractMenuEntry(String option, String target)
+	public AbstractMenuEntry(String option, String target)
 	{
 		this(option, target, -1, -1, true, true);
 	}
 
-	AbstractMenuEntry(String option, String target, boolean strictTarget)
+	public AbstractMenuEntry(String option, String target, boolean strictTarget)
 	{
 		this(option, target, -1, -1, true, strictTarget);
 	}
 
-	AbstractMenuEntry(String option, String target, int id, int type, boolean strictOption, boolean strictTarget)
+	public AbstractMenuEntry(String option, String target, int id, int type, boolean strictOption, boolean strictTarget)
 	{
 		this.option = option;
 		this.target = target;

--- a/runelite-client/src/main/java/net/runelite/client/menus/AbstractMenuEntry.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/AbstractMenuEntry.java
@@ -1,11 +1,13 @@
 package net.runelite.client.menus;
 
 import joptsimple.internal.Strings;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import net.runelite.api.MenuEntry;
 import static net.runelite.client.menus.MenuManager.LEVEL_PATTERN;
 import net.runelite.client.util.Text;
 
+@EqualsAndHashCode
 public class AbstractMenuEntry
 {
 	@Getter
@@ -88,7 +90,7 @@ public class AbstractMenuEntry
 		return true;
 	}
 
-	boolean equals(AbstractMenuEntry other)
+	/*boolean equals(AbstractMenuEntry other)
 	{
 		return target.equals(other.getTarget())
 			&& option.equals(other.getOption())
@@ -96,5 +98,5 @@ public class AbstractMenuEntry
 			&& type == other.getType()
 			&& strictOption == other.isStrictOption()
 			&& strictTarget == other.isStrictTarget();
-	}
+	}*/
 }

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -418,6 +418,29 @@ public class MenuManager
 		priorityEntries.add(entry);
 	}
 
+	public void removePriorityEntry(String option, String target)
+	{
+		option = Text.standardize(option);
+		target = Text.standardize(target);
+
+		AbstractMenuEntry entry = new AbstractMenuEntry(option, target);
+
+		Set<AbstractMenuEntry> toRemove = new HashSet<>();
+		for (AbstractMenuEntry priorityEntry : priorityEntries)
+		{
+			if (entry.equals(priorityEntry))
+			{
+				toRemove.add(entry);
+			}
+		}
+
+		for (AbstractMenuEntry e : toRemove)
+		{
+			priorityEntries.remove(e);
+		}
+	}
+
+
 	/**
 	 * Adds to the set of menu entries which when present, will remove all entries except for this one
 	 * This method will add one with strict option, but not-strict target (contains for target, equals for option)
@@ -431,34 +454,24 @@ public class MenuManager
 		priorityEntries.add(entry);
 	}
 
-	public void removePriorityEntry(String option, String target)
-	{
-		option = Text.standardize(option);
-		target = Text.standardize(target);
-
-		AbstractMenuEntry entry = new AbstractMenuEntry(option, target);
-
-		for (AbstractMenuEntry priorityEntry : priorityEntries)
-		{
-			if (entry.equals(priorityEntry))
-			{
-				priorityEntries.remove(priorityEntry);
-			}
-		}
-	}
-
 	public void removePriorityEntry(String option)
 	{
 		option = Text.standardize(option);
 
 		AbstractMenuEntry entry = new AbstractMenuEntry(option, "", false);
 
+		Set<AbstractMenuEntry> toRemove = new HashSet<>();
 		for (AbstractMenuEntry priorityEntry : priorityEntries)
 		{
 			if (entry.equals(priorityEntry))
 			{
-				priorityEntries.remove(priorityEntry);
+				toRemove.add(entry);
 			}
+		}
+
+		for (AbstractMenuEntry e : toRemove)
+		{
+			priorityEntries.remove(e);
 		}
 	}
 
@@ -515,12 +528,18 @@ public class MenuManager
 
 	public void removeSwap(AbstractMenuEntry swapFrom, AbstractMenuEntry swapTo)
 	{
+		Set<AbstractMenuEntry> toRemove = new HashSet<>();
 		for (Map.Entry<AbstractMenuEntry, AbstractMenuEntry> e : swaps.entrySet())
 		{
 			if (e.getKey().equals(swapFrom) && e.getValue().equals(swapTo))
 			{
-				swaps.remove(e.getKey());
+				toRemove.add(e.getKey());
 			}
+		}
+
+		for (AbstractMenuEntry entry : toRemove)
+		{
+			swaps.remove(entry);
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -33,6 +33,17 @@ import net.runelite.client.config.ConfigItem;
 public interface MenuEntrySwapperConfig extends Config
 {
 	@ConfigItem(
+		position = -3,
+		keyName = "customSwaps",
+		name = "Custom swaps",
+		description = "Add custom swaps here, 1 per line. Syntax: option, target : option, target<br>Note that the first entry should be the left click one!"
+	)
+	default String customSwaps()
+	{
+		return "";
+	}
+
+	@ConfigItem(
 		position = -2,
 		keyName = "shiftClickCustomization",
 		name = "Customizable shift-click",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftClickInputListener.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/ShiftClickInputListener.java
@@ -26,18 +26,10 @@ package net.runelite.client.plugins.menuentryswapper;
 
 import java.awt.event.KeyEvent;
 import javax.inject.Inject;
-import net.runelite.api.Client;
-import net.runelite.client.callback.ClientThread;
 import net.runelite.client.input.KeyListener;
 
 public class ShiftClickInputListener implements KeyListener
 {
-	@Inject
-	private ClientThread clientThread;
-
-	@Inject
-	private Client client;
-
 	@Inject
 	private MenuEntrySwapperPlugin plugin;
 
@@ -53,10 +45,11 @@ public class ShiftClickInputListener implements KeyListener
 		if (event.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
 			plugin.setShiftModifier(true);
+			plugin.startShift();
 		}
 		if (event.getKeyCode() == KeyEvent.VK_CONTROL)
 		{
-			plugin.setControlModifier(true);
+			plugin.startControl();
 		}
 	}
 
@@ -66,10 +59,11 @@ public class ShiftClickInputListener implements KeyListener
 		if (event.getKeyCode() == KeyEvent.VK_SHIFT)
 		{
 			plugin.setShiftModifier(false);
+			plugin.stopShift();
 		}
 		if (event.getKeyCode() == KeyEvent.VK_CONTROL)
 		{
-			plugin.setControlModifier(false);
+			plugin.stopControl();
 		}
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/shiftwalker/ShiftWalkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/shiftwalker/ShiftWalkerPlugin.java
@@ -48,7 +48,7 @@ import net.runelite.client.plugins.PluginType;
 public class ShiftWalkerPlugin extends Plugin
 {
 
-	private static final String WALK_HERE = "WALK HERE";
+	private static final String WALK_HERE = "Walk here";
 
 	@Inject
 	private ShiftWalkerConfig config;
@@ -91,11 +91,11 @@ public class ShiftWalkerPlugin extends Plugin
 
 	void startPrioritizing()
 	{
-		menuManager.addPriorityEntry(WALK_HERE, "");
+		menuManager.addPriorityEntry(WALK_HERE);
 	}
 
 	void stopPrioritizing()
 	{
-		menuManager.removePriorityEntry(WALK_HERE, "");
+		menuManager.removePriorityEntry(WALK_HERE);
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/util/MenuUtil.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/MenuUtil.java
@@ -33,6 +33,7 @@ import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuEntry;
 
+@Deprecated
 @Slf4j
 public class MenuUtil
 {


### PR DESCRIPTION
Also switches climb mode back to using priority entries, as that makes it work with shift to walk.

My goal is to basically remove all swap logic from most plugins and instead add it to menumanager. This of course is a lot of work so help appreciated :P