### PR TITLE
Added sorting on the item overlay, items now appear in the order that…

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -358,4 +358,26 @@ public interface GroundItemsConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "sortByGEPrice",
+		name = "Sort by GE price",
+		description = "Sorts ground items by GE price, instead of alch value",
+		position = 28
+	)
+	default boolean sortByGEPrice()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "rightClickHidden",
+		name = "Right click hidden items",
+		description = "Places hidden items below the 'Walk here' option, making it so that you need to right click to pick them up",
+		position = 29
+	)
+	default boolean rightClickHidden()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -36,6 +36,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.Comparator;
 import javax.inject.Inject;
 import net.runelite.api.Client;
 import net.runelite.api.Perspective;
@@ -164,7 +166,13 @@ public class GroundItemsOverlay extends Overlay
 
 		final boolean onlyShowLoot = config.onlyShowLoot();
 
-		for (GroundItem item : groundItemList)
+		List<GroundItem> groundItemListAsList = new ArrayList<>(groundItemList);  // make a copy so we can non-destructively modify the list
+
+		Comparator<GroundItem> compareByHaPrice = Comparator.comparingInt(GroundItem::getHaPrice);
+		Comparator<GroundItem> compareByGePrice = Comparator.comparingInt(GroundItem::getGePrice);
+		groundItemListAsList.sort(config.sortByGEPrice() ? compareByGePrice : compareByHaPrice);
+
+		for (GroundItem item : groundItemListAsList)
 		{
 			final LocalPoint groundPoint = LocalPoint.fromWorld(client, item.getLocation());
 


### PR DESCRIPTION
… they'll be picked up

Changed item menu sorting:
  Hidden items now appear at the bottom of the menu, so that hidden items don't get picked up over lower value non-hidden items

  Added a config option to put hidden items below "Walk here"
    this option makes it so that you can't accidentally pick up hidden items

  Added a config option to sort by GE value
    this option means that you'll always pick up highest GE value items first with left click
    this option also sorts the overlay by GE value