### PR TITLE
Null check playercomposition for TMorph

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/tmorph/TMorph.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/tmorph/TMorph.java
@@ -32,6 +32,7 @@ import net.runelite.api.Player;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.kit.KitType;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
@@ -84,6 +85,15 @@ public class TMorph extends Plugin
 	private void updateEquip()
 	{
 		Player player = client.getLocalPlayer();
+
+
+		if (player == null
+			|| player.getPlayerComposition() == null
+			|| client.getWidget(WidgetInfo.LOGIN_CLICK_TO_PLAY_SCREEN) != null
+			|| client.getViewportWidget() == null)
+		{
+			return;
+		}
 
 		final int mainhandID = ObjectUtils.defaultIfNull(player.getPlayerComposition().
 			getEquipmentId(KitType.WEAPON), 0);


### PR DESCRIPTION
Stops
```
java.lang.NullPointerException: null
	at net.runelite.client.plugins.tmorph.TMorph.updateEquip(TMorph.java:98)
	at net.runelite.client.plugins.tmorph.TMorph.onGameStateChanged(TMorph.java:82)
	at net.runelite.client.eventbus.EventBus$Subscriber.invoke(EventBus.java:72)
	at net.runelite.client.eventbus.EventBus.post(EventBus.java:218)
	at net.runelite.client.callback.Hooks.post(Hooks.java:137)
	at client.gameStateChanged(client.java:1015)
	at jr.fn(jr.java:1189)
	at o.hh(o.java:5478)
	at client.av(client.java:999)
	at bf.aa(bf.java:359)
	at bf.run(bf.java:338)
	at java.lang.Thread.run(Thread.java:748)
```