### PR TITLE
Make examineplugin stop running getItemComposition on executor thread

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/game/ItemManager.java
@@ -412,6 +412,20 @@ public class ItemManager
 		return price;
 	}
 
+	public int getAlchValue(ItemComposition composition)
+	{
+		if (composition.getId() == ItemID.COINS_995)
+		{
+			return 1;
+		}
+		if (composition.getId() == ItemID.PLATINUM_TOKEN)
+		{
+			return 1000;
+		}
+
+		return (int) Math.max(1, composition.getPrice() * HIGH_ALCHEMY_CONSTANT);
+	}
+
 	public int getAlchValue(int itemID)
 	{
 		if (itemID == ItemID.COINS_995)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -322,7 +322,7 @@ public class ExaminePlugin extends Plugin
 		quantity = Math.max(1, quantity);
 		int itemCompositionPrice = itemComposition.getPrice();
 		final int gePrice = itemManager.getItemPrice(id);
-		final int alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(id);
+		final int alchPrice = itemCompositionPrice <= 0 ? 0 : itemManager.getAlchValue(itemComposition);
 
 		if (gePrice > 0 || alchPrice > 0)
 		{


### PR DESCRIPTION
fixes
```
2019-05-31 17:08:55 [pool-2-thread-1] WARN  n.r.c.util.RunnableExceptionLogger - Uncaught exception in runnable net.runelite.client.plugins.examine.ExaminePlugin$$Lambda$1053/1393675677@1d40de09
java.lang.AssertionError: getItemComposition must be called on client thread
	at net.runelite.client.game.ItemManager.getItemComposition(ItemManager.java:478)
	at net.runelite.client.game.ItemManager.getAlchValue(ItemManager.java:426)
	at net.runelite.client.plugins.examine.ExaminePlugin.getItemPrice(ExaminePlugin.java:325)
	at net.runelite.client.plugins.examine.ExaminePlugin.lambda$onChatMessage$0(ExaminePlugin.java:212)
	at net.runelite.client.util.RunnableExceptionLogger.run(RunnableExceptionLogger.java:41)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```