### PR TITLE
Update Blackjack Plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/blackjack/BlackjackPlugin.java
@@ -24,30 +24,30 @@
  */
 package net.runelite.client.plugins.blackjack;
 
-import com.google.inject.Binder;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
-import static net.runelite.api.Varbits.QUEST_THE_FEUD;
+import net.runelite.api.GameState;
+import net.runelite.api.Varbits;
 import net.runelite.api.events.ChatMessage;
-import net.runelite.api.events.GameTick;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.client.eventbus.Subscribe;
-import net.runelite.client.menus.MenuManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
-import static net.runelite.client.util.MenuUtil.swap;
+import net.runelite.client.util.MenuUtil;
+import net.runelite.client.util.Text;
+import org.apache.commons.lang3.RandomUtils;
 
 /**
  * Authors gazivodag longstreet
  */
 @PluginDescriptor(
 	name = "Blackjack",
-	description = "Uses chat messages and tick timers instead of animations to read",
+	description = "Allows for one-click blackjacking, both knocking out and pickpocketing",
 	tags = {"blackjack", "thieving"},
 	type = PluginType.SKILLING
 )
@@ -55,111 +55,51 @@ import static net.runelite.client.util.MenuUtil.swap;
 @Slf4j
 public class BlackjackPlugin extends Plugin
 {
-	private static final String PICKPOCKET = "Pickpocket";
-	private static final String KNOCK_OUT = "Knock-out";
-	private static final String LURE = "Lure";
-	private static final String BANDIT = "Bandit";
-	private static final String MENAPHITE = "Menaphite Thug";
+	private static int POLLNIVNEACH_REGION = 13358;
 
 	@Inject
 	private Client client;
 
-	@Inject
-	private MenuManager menuManager;
+	private boolean isKnockedOut = false;
+	private boolean ableToBlackJack = false;
 
-	private int lastKnockout;
-	private boolean pickpocketing;
-	private boolean ableToBlackJack;
-
-	@Override
-	public void configure(Binder binder)
-	{
-	}
-
-	@Override
-	protected void startUp() throws Exception
-	{
-		menuManager.addPriorityEntry(LURE, BANDIT);
-		menuManager.addPriorityEntry(LURE, MENAPHITE);
-
-		menuManager.addPriorityEntry(KNOCK_OUT, BANDIT);
-		menuManager.addPriorityEntry(KNOCK_OUT, MENAPHITE);
-	}
-
-	@Override
-	protected void shutDown() throws Exception
-	{
-		menuManager.removePriorityEntry(LURE, BANDIT);
-		menuManager.removePriorityEntry(LURE, MENAPHITE);
-
-		menuManager.removePriorityEntry(PICKPOCKET, BANDIT);
-		menuManager.removePriorityEntry(PICKPOCKET, MENAPHITE);
-
-		menuManager.removePriorityEntry(KNOCK_OUT, BANDIT);
-		menuManager.removePriorityEntry(KNOCK_OUT, MENAPHITE);
-	}
-
-	@Subscribe
-	public void onGameTick(GameTick gameTick)
-	{
-		if (ableToBlackJack && pickpocketing && client.getTickCount() >= lastKnockout + 4)
-		{
-			pickpocketing = false;
-
-			menuManager.removePriorityEntry(PICKPOCKET, BANDIT);
-			menuManager.removePriorityEntry(PICKPOCKET, MENAPHITE);
-
-			menuManager.addPriorityEntry(KNOCK_OUT, BANDIT);
-			menuManager.addPriorityEntry(KNOCK_OUT, MENAPHITE);
-		}
-	}
+	private long nextKnockOutTick = 0;
 
 	@Subscribe
 	public void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		// Lure has higher priority than knock-out
-		if (event.getTarget().contains(MENAPHITE) || event.getTarget().contains(BANDIT)
-			&& event.getOption().equals(LURE))
+		if (client.getGameState() != GameState.LOGGED_IN
+			|| (client.getLocalPlayer().getWorldLocation().getRegionID() != POLLNIVNEACH_REGION || !ableToBlackJack))
 		{
-			swap(client, KNOCK_OUT, LURE, event.getTarget(), false);
+			return;
+		}
+
+		String option = Text.removeTags(event.getOption().toLowerCase());
+		String target = Text.removeTags(event.getTarget().toLowerCase());
+		if (isKnockedOut && nextKnockOutTick >= client.getTickCount())
+		{
+			MenuUtil.swap(client, "pickpocket", option, target);
+		}
+		else
+		{
+			MenuUtil.swap(client, "knock-out", option, target);
 		}
 	}
 
 	@Subscribe
-	public void onChatMessage(ChatMessage chatMessage)
+	public void onChatMessage(ChatMessage event)
 	{
-		if (chatMessage.getType() == ChatMessageType.SPAM)
+		if (event.getType() == ChatMessageType.SPAM
+			&& event.getMessage().equals("You smack the bandit over the head and render them unconscious."))
 		{
-			if (chatMessage.getMessage().equals("You smack the bandit over the head and render them unconscious.")
-				|| chatMessage.getMessage().equals("Your blow only glances off the bandit's head."))
-			{
-				menuManager.removePriorityEntry(KNOCK_OUT, BANDIT);
-				menuManager.removePriorityEntry(KNOCK_OUT, MENAPHITE);
-
-				menuManager.addPriorityEntry(PICKPOCKET, BANDIT);
-				menuManager.addPriorityEntry(PICKPOCKET, MENAPHITE);
-
-				lastKnockout = client.getTickCount();
-				pickpocketing = true;
-			}
+			isKnockedOut = true;
+			nextKnockOutTick = client.getTickCount() + RandomUtils.nextInt(3, 4);
 		}
 	}
 
 	@Subscribe
 	public void onVarbitChanged(VarbitChanged event)
 	{
-		ableToBlackJack = client.getVar(QUEST_THE_FEUD) >= 13;
-
-		if (!ableToBlackJack)
-		{
-			menuManager.removePriorityEntry(LURE, BANDIT);
-			menuManager.removePriorityEntry(LURE, MENAPHITE);
-
-			menuManager.removePriorityEntry(KNOCK_OUT, BANDIT);
-			menuManager.removePriorityEntry(KNOCK_OUT, MENAPHITE);
-
-			menuManager.removePriorityEntry(PICKPOCKET, BANDIT);
-			menuManager.removePriorityEntry(PICKPOCKET, MENAPHITE);
-		}
+		ableToBlackJack = client.getVar(Varbits.QUEST_THE_FEUD) >= 13;
 	}
 }


### PR DESCRIPTION
Fixes #363
 - Don't utilize MenuManager's priority methods and instead only swap
   - Originally this did clean up the menu more when right clicking, but if you're using this plugin, you're only left clicking so there doesn't seem to be any point. I believe this is what caused issue #363.
 - Don't utilize onGameTick event
 - Add region checking to avoid unnecessary calls