### PR TITLE
Only swap when holding shift for banking and shopping

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -792,4 +792,9 @@ public class MenuManager
 	{
 		hiddenEntries.remove(entry);
 	}
+
+	public void clearSwaps()
+	{
+		swaps.clear();
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -793,8 +793,9 @@ public class MenuManager
 		hiddenEntries.remove(entry);
 	}
 
-	public void clearSwaps()
+	public void clearAllSwaps()
 	{
+		priorityEntries.clear();
 		swaps.clear();
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -53,10 +53,22 @@ import net.runelite.client.plugins.menuentryswapper.util.XericsTalismanMode;
 public interface MenuEntrySwapperConfig extends Config
 {
 	@ConfigItem(
+		keyName = "shiftBanking",
+		name = "Only When Holding Shift",
+		description = "Only use withdraw/deposit",
+		position = 0,
+		group = "Banking"
+	)
+	default boolean shiftWithdrawal()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "withdrawOne",
 		name = "Withdraw/Deposit One",
 		description = "",
-		position = 0,
+		position = 1,
 		group = "Banking"
 	)
 	default boolean getWithdrawOne()
@@ -68,7 +80,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawOneItems",
 		name = "Items",
 		description = "",
-		position = 1,
+		position = 2,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawOne"
@@ -82,7 +94,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawFive",
 		name = "Withdraw/Deposit Five",
 		description = "",
-		position = 2,
+		position = 3,
 		group = "Banking"
 	)
 	default boolean getWithdrawFive()
@@ -94,7 +106,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawFiveItems",
 		name = "Items",
 		description = "",
-		position = 3,
+		position = 4,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawFive"
@@ -108,7 +120,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawTen",
 		name = "Withdraw/Deposit Ten",
 		description = "",
-		position = 4,
+		position = 5,
 		group = "Banking"
 	)
 	default boolean getWithdrawTen()
@@ -120,7 +132,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawTenItems",
 		name = "Items",
 		description = "",
-		position = 5,
+		position = 6,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawTen"
@@ -134,7 +146,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawX",
 		name = "Withdraw/Deposit X",
 		description = "",
-		position = 6,
+		position = 7,
 		group = "Banking"
 	)
 	default boolean getWithdrawX()
@@ -146,7 +158,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawXAmount",
 		name = "Amount",
 		description = "",
-		position = 7,
+		position = 8,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawX"
@@ -160,7 +172,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawXItems",
 		name = "Items",
 		description = "",
-		position = 8,
+		position = 9,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawX"
@@ -174,7 +186,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawAll",
 		name = "Withdraw/Deposit All",
 		description = "",
-		position = 9,
+		position = 10,
 		group = "Banking"
 	)
 	default boolean getWithdrawAll()
@@ -186,7 +198,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "withdrawAllItems",
 		name = "Items",
 		description = "",
-		position = 10,
+		position = 11,
 		group = "Banking",
 		hidden = true,
 		unhide = "withdrawAll"
@@ -202,7 +214,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapMax",
 		name = "Swap Max Cape",
 		description = "Enables swapping max cape options in worn interface.",
-		position = 11,
+		position = 12,
 		group = "Equipment swapper"
 	)
 	default boolean swapMax()
@@ -214,7 +226,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "maxMode",
 		name = "Mode",
 		description = "",
-		position = 12,
+		position = 13,
 		group = "Equipment swapper",
 		hidden = true,
 		unhide = "swapMax"
@@ -228,7 +240,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapArdougneCape",
 		name = "Swap Ardougne Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 13,
+		position = 14,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapArdougneCape()
@@ -240,7 +252,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapConstructionCape",
 		name = "Swap Construction Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 14,
+		position = 15,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapConstructionCape()
@@ -252,7 +264,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapCraftingCape",
 		name = "Swap Crafting Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 15,
+		position = 16,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapCraftingCape()
@@ -264,7 +276,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapMagicCape",
 		name = "Swap Magic Cape",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
-		position = 16,
+		position = 17,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapMagicCape()
@@ -276,7 +288,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapExplorersRing",
 		name = "Swap Explorer's Ring",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
-		position = 17,
+		position = 18,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapExplorersRing()
@@ -288,7 +300,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAdmire",
 		name = "Admire",
 		description = "Swap 'Admire' with 'Teleport', 'Spellbook' and 'Perks' (max cape) for mounted skill capes.",
-		position = 18,
+		position = 19,
 		group = "Equipment swapper"
 	)
 	default boolean swapAdmire()
@@ -328,7 +340,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "customSwaps",
 		name = "Custom Swaps",
 		description = "Add custom swaps here, 1 per line. Syntax: option, target : option, target<br>Note that the first entry should be the left click one!",
-		position = 19,
+		position = 20,
 		group = "Miscellaneous",
 		parse = true,
 		clazz = Parse.class,
@@ -343,7 +355,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "shiftClickCustomization",
 		name = "Customizable Shift-click",
 		description = "Allows customization of shift-clicks on items.",
-		position = 20,
+		position = 21,
 		group = "Miscellaneous"
 	)
 	default boolean shiftClickCustomization()
@@ -355,7 +367,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBirdhouseEmpty",
 		name = "Birdhouse",
 		description = "Swap 'Interact' with 'Empty' for birdhouses on Fossil Island.",
-		position = 21,
+		position = 22,
 		group = "Miscellaneous"
 	)
 	default boolean swapBirdhouseEmpty()
@@ -367,7 +379,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBones",
 		name = "Bury",
 		description = "Swap 'Bury' with 'Use' on Bones.",
-		position = 22,
+		position = 23,
 		group = "Miscellaneous"
 	)
 	default boolean swapBones()
@@ -379,7 +391,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapChase",
 		name = "Chase",
 		description = "Allows to left click your cat to chase rats.",
-		position = 23,
+		position = 24,
 		group = "Miscellaneous"
 	)
 	default boolean swapChase()
@@ -391,7 +403,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHarpoon",
 		name = "Harpoon",
 		description = "Swap 'Cage', 'Big Net' with 'Harpoon' on Fishing spots.",
-		position = 24,
+		position = 25,
 		group = "Miscellaneous"
 	)
 	default boolean swapHarpoon()
@@ -403,7 +415,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapOccult",
 		name = "Occult Altar",
 		description = "Swap 'Venerate' with 'Ancient', 'Lunar', or 'Arceuus' on an Altar of the Occult.",
-		position = 25,
+		position = 26,
 		group = "Miscellaneous"
 	)
 	default boolean swapOccult()
@@ -415,7 +427,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "occultalter",
 		name = "Mode",
 		description = "",
-		position = 26,
+		position = 27,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "swapOccult"
@@ -429,7 +441,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHomePortal",
 		name = "Home",
 		description = "Swap 'Enter' with 'Home', 'Build' or 'Friend's house' on Portal.",
-		position = 27,
+		position = 28,
 		group = "Miscellaneous"
 	)
 	default boolean swapHomePortal()
@@ -441,7 +453,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "home",
 		name = "Mode",
 		description = "",
-		position = 28,
+		position = 29,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "swapHomePortal"
@@ -455,7 +467,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPrivate",
 		name = "Private",
 		description = "Swap 'Shared' with 'Private' on the Chambers of Xeric storage units.",
-		position = 29,
+		position = 30,
 		group = "Miscellaneous"
 	)
 	default boolean swapPrivate()
@@ -467,7 +479,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPick",
 		name = "Pick",
 		description = "Swap 'Pick' with 'Pick-lots' of the Gourd tree in the Chambers of Xeric.",
-		position = 30,
+		position = 31,
 		group = "Miscellaneous"
 	)
 	default boolean swapPick()
@@ -479,7 +491,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapQuick",
 		name = "Quick Pass/Open/Start/Travel",
 		description = "Swap 'Pass' with 'Quick-Pass', 'Open' with 'Quick-Open', 'Ring' with 'Quick-Start' and 'Talk-to' with 'Quick-Travel'.",
-		position = 31,
+		position = 32,
 		group = "Miscellaneous"
 	)
 	default boolean swapQuick()
@@ -491,7 +503,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBoxTrap",
 		name = "Reset",
 		description = "Swap 'Check' with 'Reset' on box traps.",
-		position = 32,
+		position = 33,
 		group = "Miscellaneous"
 	)
 	default boolean swapBoxTrap()
@@ -503,7 +515,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "rockCake",
 		name = "Rock Cake Guzzle",
 		description = "Enables Left Click 'Guzzle' on the Dwarven Rock Cake.",
-		position = 33,
+		position = 34,
 		group = "Miscellaneous"
 	)
 	default boolean rockCake()
@@ -515,7 +527,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapRogueschests",
 		name = "Rogues Chests",
 		description = "Swap Rogues Chests from 'Open' to 'Search for traps'.",
-		position = 34,
+		position = 35,
 		group = "Miscellaneous"
 	)
 	default boolean swapRogueschests()
@@ -527,7 +539,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapClimbUpDown",
 		name = "Climb",
 		description = "Swap 'Climb-Up'/'Climb-Down' depending on Shift or Control key.",
-		position = 35,
+		position = 36,
 		group = "Miscellaneous"
 	)
 	default boolean swapClimbUpDown()
@@ -539,7 +551,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapStun",
 		name = "Stun Hoop Snakes",
 		description = "Swap 'Attack' with 'Stun'.",
-		position = 36,
+		position = 37,
 		group = "Miscellaneous"
 	)
 	default boolean swapStun()
@@ -551,7 +563,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSearch",
 		name = "Search",
 		description = "Swap 'Close', 'Shut' with 'Search' on chests, cupboards, etc.",
-		position = 37,
+		position = 38,
 		group = "Miscellaneous"
 	)
 	default boolean swapSearch()
@@ -563,7 +575,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHardWoodGrove",
 		name = "Hardwood Grove",
 		description = "Swap 'Quick-Pay(100)' and 'Send-Parcel' at Hardwood Grove.",
-		position = 38,
+		position = 39,
 		group = "Miscellaneous"
 	)
 	default boolean swapHardWoodGrove()
@@ -576,7 +588,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "removeObjects",
 		name = "Remove Objects",
 		description = "Removes interaction with the listed objects.",
-		position = 39,
+		position = 40,
 		group = "Miscellaneous"
 	)
 	default boolean getRemoveObjects()
@@ -588,7 +600,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "removedObjects",
 		name = "Objects",
 		description = "Objects listed here will have all interaction be removed.",
-		position = 40,
+		position = 41,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "removeObjects"
@@ -602,7 +614,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapslayer",
 		name = "Swap Slayer Ring",
 		description = "",
-		position = 41,
+		position = 42,
 		group = "Teleportation"
 	)
 	default boolean getSlayerRing()
@@ -614,7 +626,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "slayerringmode",
 		name = "Mode",
 		description = "",
-		position = 42,
+		position = 43,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapslayer"
@@ -630,7 +642,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyOne",
 		name = "Swappable Buy One",
 		description = "",
-		position = 43,
+		position = 44,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyOne()
@@ -643,7 +655,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Items",
 		description = "",
 		group = "Shop / stores",
-		position = 44,
+		position = 45,
 		hidden = true,
 		unhide = "swapBuyOne"
 	)
@@ -656,7 +668,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFive",
 		name = "Swappable Buy Five",
 		description = "",
-		position = 45,
+		position = 46,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFive()
@@ -668,7 +680,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiveItems",
 		name = "Items",
 		description = "",
-		position = 46,
+		position = 47,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFive"
@@ -682,7 +694,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyTen",
 		name = "Swappable Buy Ten",
 		description = "",
-		position = 47,
+		position = 48,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyTen()
@@ -694,7 +706,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyTenItems",
 		name = "Items",
 		description = "",
-		position = 48,
+		position = 49,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyTen"
@@ -708,7 +720,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFifty",
 		name = "Swappable Buy Fifty",
 		description = "",
-		position = 49,
+		position = 50,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFifty()
@@ -720,7 +732,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiftyItems",
 		name = "Items",
 		description = "",
-		position = 50,
+		position = 51,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFifty"
@@ -734,7 +746,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellOne",
 		name = "Swappable Sell One",
 		description = "",
-		position = 51,
+		position = 52,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellOne()
@@ -746,7 +758,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellOneItems",
 		name = "Items",
 		description = "",
-		position = 52,
+		position = 53,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellOne"
@@ -760,7 +772,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFive",
 		name = "Swappable Sell Five",
 		description = "",
-		position = 53,
+		position = 54,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFive()
@@ -772,7 +784,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiveItems",
 		name = "Items",
 		description = "",
-		position = 54,
+		position = 55,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFive"
@@ -786,7 +798,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellTen",
 		name = "Swappable Sell Ten",
 		description = "",
-		position = 55,
+		position = 56,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellTen()
@@ -798,7 +810,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellTenItems",
 		name = "Items",
 		description = "",
-		position = 56,
+		position = 57,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellTen"
@@ -812,7 +824,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFifty",
 		name = "Swappable Sell Fifty",
 		description = "",
-		position = 57,
+		position = 58,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFifty()
@@ -824,7 +836,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiftyItems",
 		name = "Items",
 		description = "",
-		position = 58,
+		position = 59,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFifty"
@@ -840,7 +852,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "easyConstruction",
 			name = "Easy Construction",
 			description = "Makes 'Remove'/'Build' the default option for listed item ID's in build mode.<br>Tip: Use dev tools \"'Game Objects\" to find out the ID!",
-			position = 59,
+			position = 60,
 			group = "Skilling"
 	)
 	default boolean getEasyConstruction()
@@ -852,7 +864,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "constructionItems",
 			name = "Construction Items",
 			description = "Makes 'Remove'/'Build' the default option for listed item ID's in build mode.<br>Tip: Use dev tools \"Game Objects\" to find out the ID, and separate values with a ','",
-			position = 60,
+			position = 61,
 			group = "Skilling",
 			hidden = true,
 			unhide = "easyConstruction"
@@ -866,7 +878,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstruction",
 		name = "Easy Construction",
 		description = "Makes 'Remove'/'Build' the default option for listed items.",
-		position = 59,
+		position = 60,
 		group = "Skilling"
 	)
 
@@ -879,7 +891,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstructionItems",
 		name = "Build Items",
 		description = "",
-		position = 60,
+		position = 61,
 		group = "Skilling",
 		hidden = true,
 		unhide = "getTempConstruction"
@@ -893,7 +905,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSmithing",
 		name = "Swap Smithing",
 		description = "Enables swapping of 'Smith-1' and 'Smith-all' options.",
-		position = 61,
+		position = 62,
 		group = "Skilling"
 	)
 	default boolean getSwapSmithing()
@@ -905,7 +917,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTanning",
 		name = "Swap Tanning",
 		description = "Enables swapping of 'Tan-1' and 'Tan-all' options.",
-		position = 62,
+		position = 63,
 		group = "Skilling"
 	)
 	default boolean getSwapTanning()
@@ -917,7 +929,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmill",
 		name = "Swap Sawmill Operator",
 		description = "Makes 'Buy-plank' the default option on the Sawmill Operator.",
-		position = 63,
+		position = 64,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmill()
@@ -929,7 +941,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmillPlanks",
 		name = "Swap Buy Planks",
 		description = "Makes 'Buy All' the default option when buying planks.",
-		position = 64,
+		position = 65,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmillPlanks()
@@ -941,7 +953,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPuroPuro",
 		name = "Swap Puro-Puro Wheat",
 		description = "",
-		position = 65,
+		position = 66,
 		group = "Skilling"
 	)
 	default boolean getSwapPuro()
@@ -955,7 +967,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap 'Talk-to' with 'Assignment' for Slayer Masters. This will take priority over swapping Trade.",
-		position = 66,
+		position = 67,
 		group = "Talk-To"
 	)
 	default boolean swapAssignment()
@@ -967,7 +979,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBanker",
 		name = "Bank",
 		description = "Swap 'Talk-to' with 'Bank' on Bank NPCs.<br>Example: Banker.",
-		position = 67,
+		position = 68,
 		group = "Talk-To"
 	)
 	default boolean swapBank()
@@ -979,7 +991,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapContract",
 		name = "Contract",
 		description = "Swap 'Talk-to' with 'Contract' on Guildmaster Jane.",
-		position = 68,
+		position = 69,
 		group = "Talk-To"
 	)
 	default boolean swapContract()
@@ -991,7 +1003,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "claimDynamite",
 		name = "Claim Dynamite",
 		description = "Swap 'Talk-to' with 'Claim Dynamite' on Thirus.",
-		position = 69,
+		position = 70,
 		group = "Talk-To"
 	)
 	default boolean claimDynamite()
@@ -1003,7 +1015,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "claimSlime",
 		name = "Claim Slime",
 		description = "Swap 'Talk-to' with 'Claim Slime' from Morytania diaries.",
-		position = 70,
+		position = 71,
 		group = "Talk-To"
 	)
 	default boolean claimSlime()
@@ -1015,7 +1027,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDarkMage",
 		name = "Repairs",
 		description = "Swap 'Talk-to' with 'Repairs' for Dark Mage.",
-		position = 71,
+		position = 72,
 		group = "Talk-To"
 	)
 	default boolean swapDarkMage()
@@ -1027,7 +1039,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDecant",
 		name = "Decant",
 		description = "Swap 'Talk-to' with 'Decant' for Bob Barter and Murky Matt at the Grand Exchange.",
-		position = 72,
+		position = 73,
 		group = "Talk-To"
 	)
 	default boolean swapDecant()
@@ -1039,7 +1051,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapExchange",
 		name = "Exchange",
 		description = "Swap 'Talk-to' with 'Exchange' on various NPCs.<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight.",
-		position = 73,
+		position = 74,
 		group = "Talk-To"
 	)
 	default boolean swapExchange()
@@ -1051,7 +1063,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPickpocket",
 		name = "Pickpocket on H.A.M.",
 		description = "Swap 'Talk-to' with 'Pickpocket' on H.A.M members.",
-		position = 74,
+		position = 75,
 		group = "Talk-To"
 	)
 	default boolean swapPickpocket()
@@ -1063,7 +1075,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPay",
 		name = "Pay",
 		description = "Swap 'Talk-to' with 'Pay' on various NPCs.<br>Example: Elstan, Heskel, Fayeth.",
-		position = 75,
+		position = 76,
 		group = "Talk-To"
 	)
 	default boolean swapPay()
@@ -1075,7 +1087,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap 'Talk-to' with 'Teleport' for the Mage of Zamorak.",
-		position = 76,
+		position = 77,
 		group = "Talk-To"
 	)
 	default boolean swapAbyssTeleport()
@@ -1087,7 +1099,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap 'Talk-to' with 'Trade' on various NPCs.<br>Example: Shop keeper, Shop assistant.",
-		position = 77,
+		position = 78,
 		group = "Talk-To"
 	)
 	default boolean swapTrade()
@@ -1099,7 +1111,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTravel",
 		name = "Travel",
 		description = "Swap 'Talk-to' with 'Travel', 'Take-boat', 'Pay-fare', 'Charter' on various NPCs.<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember.",
-		position = 78,
+		position = 79,
 		group = "Talk-To"
 	)
 	default boolean swapTravel()
@@ -1111,7 +1123,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDream",
 		name = "Dream",
 		description = "Swap 'Talk-to' with 'Dream' for Dominic Onion.",
-		position = 79,
+		position = 80,
 		group = "Talk-To"
 	)
 	default boolean swapDream()
@@ -1123,7 +1135,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapStory",
 		name = "Story",
 		description = "Swap 'Talk-to' with 'Story' for Juna at Tears of Guthix.",
-		position = 80,
+		position = 81,
 		group = "Talk-To"
 	)
 	default boolean swapStory()
@@ -1135,7 +1147,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPlank",
 		name = "Buy Planks",
 		description = "Swap 'Talk-to' with 'Buy-planks' at the Lumber Yard.",
-		position = 81,
+		position = 82,
 		group = "Talk-To"
 	)
 	default boolean swapPlank()
@@ -1147,7 +1159,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapMetamorphosis",
 		name = "Metamorphosis",
 		description = "Swap 'Talk-to' with 'Metamorphosis' for Baby Chinchompa pet.",
-		position = 82,
+		position = 83,
 		group = "Talk-To"
 	)
 	default boolean swapMetamorphosis()
@@ -1159,7 +1171,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapEscort",
 		name = "Escort",
 		description = "Swap 'Talk-to' with 'Escort' for the Temple Trekking mini-game.",
-		position = 83,
+		position = 84,
 		group = "Talk-To"
 	)
 	default boolean swapEscort()
@@ -1173,7 +1185,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapFairyRing",
 		name = "Fairy Ring",
 		description = "Swap 'Zanaris' with 'Last-destination' or 'Configure' on Fairy rings.",
-		position = 84,
+		position = 85,
 		group = "Teleportation"
 	)
 	default boolean swapFairyRing()
@@ -1185,7 +1197,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "fairyring",
 		name = "Mode",
 		description = "",
-		position = 85,
+		position = 86,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapFairyRing"
@@ -1199,7 +1211,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapObelisk",
 		name = "Obelisk",
 		description = "Swap the options on wilderness obelisks between 'Activate', 'Set destination' or 'Teleport to destination'.",
-		position = 86,
+		position = 87,
 		group = "Teleportation"
 	)
 	default boolean swapObelisk()
@@ -1211,7 +1223,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "obelisk",
 		name = "Mode",
 		description = "",
-		position = 87,
+		position = 88,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapObelisk"
@@ -1225,7 +1237,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTeleportItem",
 		name = "Teleport Items",
 		description = "Swap 'Wear' or 'Wield' with 'Rub' or 'Teleport' on teleport items.<br>Example: Amulet of glory, Explorer's ring, Chronicle.",
-		position = 88,
+		position = 89,
 		group = "Teleportation"
 	)
 	default boolean swapTeleportItem()
@@ -1237,7 +1249,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapWildernessLever",
 		name = "Wilderness Lever",
 		description = "Swap the wilderness lever left click to be Edgeville/Ardougne.",
-		position = 89,
+		position = 90,
 		group = "Teleportation"
 	)
 	default boolean swapWildernessLever()
@@ -1249,7 +1261,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapNexus",
 		name = "Portal Nexus",
 		description = "Makes the teleport menu have priority over the left click destination on the portal nexus.",
-		position = 90,
+		position = 91,
 		group = "Teleportation"
 	)
 	default boolean swapNexus()
@@ -1261,7 +1273,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGamesNecklace",
 		name = "Swap Games Necklace",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Games Necklace.",
-		position = 91,
+		position = 92,
 		group = "Teleportation"
 	)
 	default boolean getGamesNecklace()
@@ -1273,7 +1285,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gamesNecklaceMode",
 		name = "Mode",
 		description = "",
-		position = 92,
+		position = 93,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGamesNecklace"
@@ -1287,7 +1299,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDuelingRing",
 		name = "Swap Dueling Ring",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Dueling.",
-		position = 93,
+		position = 94,
 		group = "Teleportation"
 	)
 	default boolean getDuelingRing()
@@ -1299,7 +1311,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "duelingRingMode",
 		name = "Mode",
 		description = "",
-		position = 94,
+		position = 95,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDuelingRing"
@@ -1313,7 +1325,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGlory",
 		name = "Swap Glory",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Amulet of Glory / Amulet of Eternal Glory.",
-		position = 95,
+		position = 96,
 		group = "Teleportation"
 	)
 	default boolean getGlory()
@@ -1325,7 +1337,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gloryMode",
 		name = "Mode",
 		description = "",
-		position = 96,
+		position = 97,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGlory"
@@ -1339,7 +1351,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSkill",
 		name = "Swap Skill",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Skills Necklace.",
-		position = 97,
+		position = 98,
 		group = "Teleportation"
 	)
 	default boolean getSkillsNecklace()
@@ -1351,7 +1363,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "skillsnecklacemode",
 		name = "Mode",
 		description = "",
-		position = 98,
+		position = 99,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapSkill"
@@ -1365,7 +1377,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPassage",
 		name = "Swap Passage",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Necklace of Passage.",
-		position = 99,
+		position = 100,
 		group = "Teleportation"
 	)
 	default boolean getNecklaceofPassage()
@@ -1377,7 +1389,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "necklaceofpassagemode",
 		name = "Mode",
 		description = "",
-		position = 100,
+		position = 101,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapPassage"
@@ -1391,7 +1403,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDigsite",
 		name = "Swap Digsite",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Digsite Pendant.",
-		position = 101,
+		position = 102,
 		group = "Teleportation"
 	)
 	default boolean getDigsitePendant()
@@ -1403,7 +1415,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "digsitependantmode",
 		name = "Mode",
 		description = "",
-		position = 102,
+		position = 103,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDigsite"
@@ -1417,7 +1429,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapCombat",
 		name = "Swap Combat",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Combat Bracelet.",
-		position = 103,
+		position = 104,
 		group = "Teleportation"
 	)
 	default boolean getCombatBracelet()
@@ -1429,7 +1441,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "combatbraceletmode",
 		name = "Mode",
 		description = "",
-		position = 104,
+		position = 105,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapCombat"
@@ -1443,7 +1455,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapburning",
 		name = "Swap Burning",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Burning Amulet.",
-		position = 105,
+		position = 106,
 		group = "Teleportation"
 	)
 	default boolean getBurningAmulet()
@@ -1455,7 +1467,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "burningamuletmode",
 		name = "Mode",
 		description = "",
-		position = 106,
+		position = 107,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapburning"
@@ -1469,7 +1481,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapxeric",
 		name = "Swap Xeric's",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Xeric's Talisman.",
-		position = 107,
+		position = 108,
 		group = "Teleportation"
 	)
 	default boolean getXericsTalisman()
@@ -1481,7 +1493,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "xericstalismanmode",
 		name = "Mode",
 		description = "",
-		position = 108,
+		position = 109,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapxeric"
@@ -1495,7 +1507,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapwealth",
 		name = "Swap Wealth",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Wealth.",
-		position = 109,
+		position = 110,
 		group = "Teleportation"
 	)
 	default boolean getRingofWealth()
@@ -1507,7 +1519,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "ringofwealthmode",
 		name = "Mode",
 		description = "",
-		position = 110,
+		position = 111,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapwealth"
@@ -1523,7 +1535,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideExamine",
 		name = "Hide Examine",
 		description = "Hides the 'Examine' option from the right click menu.",
-		position = 111,
+		position = 112,
 		group = "Right Click Options"
 	)
 	default boolean hideExamine()
@@ -1535,7 +1547,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideTradeWith",
 		name = "Hide Trade With",
 		description = "Hides the 'Trade with' option from the right click menu.",
-		position = 112,
+		position = 113,
 		group = "Right Click Options"
 	)
 	default boolean hideTradeWith()
@@ -1547,7 +1559,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideReport",
 		name = "Hide Report",
 		description = "Hides the 'Report' option from the right click menu.",
-		position = 113,
+		position = 114,
 		group = "Right Click Options"
 	)
 	default boolean hideReport()
@@ -1559,7 +1571,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideLookup",
 		name = "Hide Lookup",
 		description = "Hides the 'Lookup' option from the right click menu.",
-		position = 114,
+		position = 115,
 		group = "Right Click Options"
 	)
 	default boolean hideLookup()
@@ -1571,7 +1583,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideNet",
 		name = "Hide Net",
 		description = "Hides the 'Net' option from the right click menu.",
-		position = 115,
+		position = 116,
 		group = "Right Click Options"
 	)
 	default boolean hideNet()
@@ -1583,7 +1595,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideBait",
 		name = "Hide Bait",
 		description = "Hides the 'Bait' option from the right click menu.",
-		position = 116,
+		position = 117,
 		group = "Right Click Options"
 	)
 	default boolean hideBait()
@@ -1597,7 +1609,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyRunepouch",
 			name = "Hide Destroy on Rune Pouch",
 			description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
-			position = 117,
+			position = 118,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyRunepouch()
@@ -1609,7 +1621,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyCoalbag",
 			name = "Hide Destroy on Coal bag",
 			description = "Hides the 'Destroy' option when right clicking a Coal bag.",
-			position = 118,
+			position = 119,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyCoalbag()
@@ -1621,7 +1633,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyHerbsack",
 			name = "Hide Destroy on Herb sack",
 			description = "Hides the 'Destroy' option when right clicking a Herb sack.",
-			position = 119,
+			position = 120,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyHerbsack()
@@ -1633,7 +1645,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyBoltpouch",
 			name = "Hide Destroy on Bolt pouch",
 			description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
-			position = 120,
+			position = 121,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyBoltpouch()
@@ -1645,7 +1657,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyGembag",
 			name = "Hide Destroy on Gem bag",
 			description = "Hides the 'Destroy' option when right clicking a Gem bag.",
-			position = 121,
+			position = 122,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyGembag()
@@ -1657,7 +1669,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDropRunecraftingPouch",
 			name = "Hide Drop on RC pouches",
 			description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
-			position = 122,
+			position = 123,
 			group = "Untradeables"
 	)
 	default boolean hideDropRunecraftingPouch()
@@ -1668,11 +1680,11 @@ public interface MenuEntrySwapperConfig extends Config
 	//------------------------------------------------------------//
 
 	@ConfigItem(
-			keyName = "swapImps",
-			name = "Impling Jars",
-			description = "Don't open implings if bank has a clue.",
-			position = 123,
-			group = "Miscellaneous"
+		keyName = "swapImps",
+		name = "Impling Jars",
+		description = "Don't open implings if bank has a clue.",
+		position = 124,
+		group = "Miscellaneous"
 	)
 	default boolean swapImps()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -55,7 +55,7 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 		keyName = "shiftBanking",
 		name = "Only When Holding Shift",
-		description = "Only use withdraw/deposit",
+		description = "Only swap withdraw/deposit options when holding shift",
 		position = 0,
 		group = "Banking"
 	)
@@ -78,7 +78,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawOneItems",
-		name = "Items",
+		name = "Withdraw/Deposit One Item List",
 		description = "",
 		position = 2,
 		group = "Banking",
@@ -104,7 +104,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawFiveItems",
-		name = "Items",
+		name = "Withdraw/Deposit Five Item List",
 		description = "",
 		position = 4,
 		group = "Banking",
@@ -130,7 +130,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawTenItems",
-		name = "Items",
+		name = "Withdraw/Deposit Ten Item List",
 		description = "",
 		position = 6,
 		group = "Banking",
@@ -156,7 +156,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawXAmount",
-		name = "Amount",
+		name = "Withdraw/Deposit X Amount",
 		description = "",
 		position = 8,
 		group = "Banking",
@@ -170,7 +170,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawXItems",
-		name = "Items",
+		name = "Withdraw/Deposit X Item List",
 		description = "",
 		position = 9,
 		group = "Banking",
@@ -196,7 +196,7 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "withdrawAllItems",
-		name = "Items",
+		name = "Withdraw/Deposit All Item List",
 		description = "",
 		position = 11,
 		group = "Banking",
@@ -215,7 +215,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Max Cape",
 		description = "Enables swapping max cape options in worn interface.",
 		position = 12,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean swapMax()
 	{
@@ -227,7 +227,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Mode",
 		description = "",
 		position = 13,
-		group = "Equipment swapper",
+		group = "Equipment Swapper",
 		hidden = true,
 		unhide = "swapMax"
 	)
@@ -241,7 +241,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Ardougne Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
 		position = 14,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean getSwapArdougneCape()
 	{
@@ -253,7 +253,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Construction Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
 		position = 15,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean getSwapConstructionCape()
 	{
@@ -265,7 +265,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Crafting Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
 		position = 16,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean getSwapCraftingCape()
 	{
@@ -277,7 +277,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Magic Cape",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
 		position = 17,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean getSwapMagicCape()
 	{
@@ -289,7 +289,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swap Explorer's Ring",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
 		position = 18,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean getSwapExplorersRing()
 	{
@@ -301,7 +301,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Admire",
 		description = "Swap 'Admire' with 'Teleport', 'Spellbook' and 'Perks' (max cape) for mounted skill capes.",
 		position = 19,
-		group = "Equipment swapper"
+		group = "Equipment Swapper"
 	)
 	default boolean swapAdmire()
 	{
@@ -643,7 +643,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Only When Holding Shift",
 		description = "Only swap buy/sell options when holding shift",
 		position = 44,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean shiftShopping()
 	{
@@ -655,7 +655,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Buy One",
 		description = "",
 		position = 45,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapBuyOne()
 	{
@@ -664,9 +664,9 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "buyOneItems",
-		name = "Items",
+		name = "Buy One Item List",
 		description = "",
-		group = "Shop / stores",
+		group = "Shopping",
 		position = 46,
 		hidden = true,
 		unhide = "swapBuyOne"
@@ -681,7 +681,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Buy Five",
 		description = "",
 		position = 47,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapBuyFive()
 	{
@@ -690,10 +690,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "buyFiveItems",
-		name = "Items",
+		name = "Buy Five Item List",
 		description = "",
 		position = 48,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapBuyFive"
 	)
@@ -707,7 +707,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Buy Ten",
 		description = "",
 		position = 49,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapBuyTen()
 	{
@@ -716,10 +716,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "buyTenItems",
-		name = "Items",
+		name = "Buy Ten Item List",
 		description = "",
 		position = 50,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapBuyTen"
 	)
@@ -733,7 +733,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Buy Fifty",
 		description = "",
 		position = 51,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapBuyFifty()
 	{
@@ -742,10 +742,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "buyFiftyItems",
-		name = "Items",
+		name = "Buy Fifty Item List",
 		description = "",
 		position = 52,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapBuyFifty"
 	)
@@ -759,7 +759,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Sell One",
 		description = "",
 		position = 53,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapSellOne()
 	{
@@ -768,10 +768,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "sellOneItems",
-		name = "Items",
+		name = "Sell One Item List",
 		description = "",
 		position = 54,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapSellOne"
 	)
@@ -785,7 +785,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Sell Five",
 		description = "",
 		position = 55,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapSellFive()
 	{
@@ -794,10 +794,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "sellFiveItems",
-		name = "Items",
+		name = "Sell Five Item List",
 		description = "",
 		position = 56,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapSellFive"
 	)
@@ -811,7 +811,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Sell Ten",
 		description = "",
 		position = 57,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapSellTen()
 	{
@@ -820,10 +820,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "sellTenItems",
-		name = "Items",
+		name = "Sell Ten Item List",
 		description = "",
 		position = 58,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapSellTen"
 	)
@@ -837,7 +837,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Swappable Sell Fifty",
 		description = "",
 		position = 59,
-		group = "Shop / stores"
+		group = "Shopping"
 	)
 	default boolean getSwapSellFifty()
 	{
@@ -846,10 +846,10 @@ public interface MenuEntrySwapperConfig extends Config
 
 	@ConfigItem(
 		keyName = "sellFiftyItems",
-		name = "Items",
+		name = "Sell Fifty Item List",
 		description = "",
 		position = 60,
-		group = "Shop / stores",
+		group = "Shopping",
 		hidden = true,
 		unhide = "swapSellFifty"
 	)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -639,10 +639,22 @@ public interface MenuEntrySwapperConfig extends Config
 	//------------------------------------------------------------//
 
 	@ConfigItem(
+		keyName = "shiftShopping",
+		name = "Only When Holding Shift",
+		description = "Only swap buy/sell options when holding shift",
+		position = 44,
+		group = "Shop / stores"
+	)
+	default boolean shiftShopping()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "swapBuyOne",
 		name = "Swappable Buy One",
 		description = "",
-		position = 44,
+		position = 45,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyOne()
@@ -655,7 +667,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Items",
 		description = "",
 		group = "Shop / stores",
-		position = 45,
+		position = 46,
 		hidden = true,
 		unhide = "swapBuyOne"
 	)
@@ -668,7 +680,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFive",
 		name = "Swappable Buy Five",
 		description = "",
-		position = 46,
+		position = 47,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFive()
@@ -680,7 +692,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiveItems",
 		name = "Items",
 		description = "",
-		position = 47,
+		position = 48,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFive"
@@ -694,7 +706,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyTen",
 		name = "Swappable Buy Ten",
 		description = "",
-		position = 48,
+		position = 49,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyTen()
@@ -706,7 +718,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyTenItems",
 		name = "Items",
 		description = "",
-		position = 49,
+		position = 50,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyTen"
@@ -720,7 +732,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFifty",
 		name = "Swappable Buy Fifty",
 		description = "",
-		position = 50,
+		position = 51,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFifty()
@@ -732,7 +744,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiftyItems",
 		name = "Items",
 		description = "",
-		position = 51,
+		position = 52,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFifty"
@@ -746,7 +758,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellOne",
 		name = "Swappable Sell One",
 		description = "",
-		position = 52,
+		position = 53,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellOne()
@@ -758,7 +770,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellOneItems",
 		name = "Items",
 		description = "",
-		position = 53,
+		position = 54,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellOne"
@@ -772,7 +784,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFive",
 		name = "Swappable Sell Five",
 		description = "",
-		position = 54,
+		position = 55,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFive()
@@ -784,7 +796,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiveItems",
 		name = "Items",
 		description = "",
-		position = 55,
+		position = 56,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFive"
@@ -798,7 +810,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellTen",
 		name = "Swappable Sell Ten",
 		description = "",
-		position = 56,
+		position = 57,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellTen()
@@ -810,7 +822,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellTenItems",
 		name = "Items",
 		description = "",
-		position = 57,
+		position = 58,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellTen"
@@ -824,7 +836,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFifty",
 		name = "Swappable Sell Fifty",
 		description = "",
-		position = 58,
+		position = 59,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFifty()
@@ -836,7 +848,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiftyItems",
 		name = "Items",
 		description = "",
-		position = 59,
+		position = 60,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFifty"
@@ -852,7 +864,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "easyConstruction",
 			name = "Easy Construction",
 			description = "Makes 'Remove'/'Build' the default option for listed item ID's in build mode.<br>Tip: Use dev tools \"'Game Objects\" to find out the ID!",
-			position = 60,
+			position = 61,
 			group = "Skilling"
 	)
 	default boolean getEasyConstruction()
@@ -864,7 +876,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "constructionItems",
 			name = "Construction Items",
 			description = "Makes 'Remove'/'Build' the default option for listed item ID's in build mode.<br>Tip: Use dev tools \"Game Objects\" to find out the ID, and separate values with a ','",
-			position = 61,
+			position = 62,
 			group = "Skilling",
 			hidden = true,
 			unhide = "easyConstruction"
@@ -878,7 +890,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstruction",
 		name = "Easy Construction",
 		description = "Makes 'Remove'/'Build' the default option for listed items.",
-		position = 60,
+		position = 61,
 		group = "Skilling"
 	)
 
@@ -891,7 +903,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstructionItems",
 		name = "Build Items",
 		description = "",
-		position = 61,
+		position = 62,
 		group = "Skilling",
 		hidden = true,
 		unhide = "getTempConstruction"
@@ -905,7 +917,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSmithing",
 		name = "Swap Smithing",
 		description = "Enables swapping of 'Smith-1' and 'Smith-all' options.",
-		position = 62,
+		position = 63,
 		group = "Skilling"
 	)
 	default boolean getSwapSmithing()
@@ -917,7 +929,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTanning",
 		name = "Swap Tanning",
 		description = "Enables swapping of 'Tan-1' and 'Tan-all' options.",
-		position = 63,
+		position = 64,
 		group = "Skilling"
 	)
 	default boolean getSwapTanning()
@@ -929,7 +941,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmill",
 		name = "Swap Sawmill Operator",
 		description = "Makes 'Buy-plank' the default option on the Sawmill Operator.",
-		position = 64,
+		position = 65,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmill()
@@ -941,7 +953,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmillPlanks",
 		name = "Swap Buy Planks",
 		description = "Makes 'Buy All' the default option when buying planks.",
-		position = 65,
+		position = 66,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmillPlanks()
@@ -953,7 +965,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPuroPuro",
 		name = "Swap Puro-Puro Wheat",
 		description = "",
-		position = 66,
+		position = 67,
 		group = "Skilling"
 	)
 	default boolean getSwapPuro()
@@ -967,7 +979,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap 'Talk-to' with 'Assignment' for Slayer Masters. This will take priority over swapping Trade.",
-		position = 67,
+		position = 68,
 		group = "Talk-To"
 	)
 	default boolean swapAssignment()
@@ -979,7 +991,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBanker",
 		name = "Bank",
 		description = "Swap 'Talk-to' with 'Bank' on Bank NPCs.<br>Example: Banker.",
-		position = 68,
+		position = 69,
 		group = "Talk-To"
 	)
 	default boolean swapBank()
@@ -991,7 +1003,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapContract",
 		name = "Contract",
 		description = "Swap 'Talk-to' with 'Contract' on Guildmaster Jane.",
-		position = 69,
+		position = 70,
 		group = "Talk-To"
 	)
 	default boolean swapContract()
@@ -1003,7 +1015,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "claimDynamite",
 		name = "Claim Dynamite",
 		description = "Swap 'Talk-to' with 'Claim Dynamite' on Thirus.",
-		position = 70,
+		position = 71,
 		group = "Talk-To"
 	)
 	default boolean claimDynamite()
@@ -1015,7 +1027,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "claimSlime",
 		name = "Claim Slime",
 		description = "Swap 'Talk-to' with 'Claim Slime' from Morytania diaries.",
-		position = 71,
+		position = 72,
 		group = "Talk-To"
 	)
 	default boolean claimSlime()
@@ -1027,7 +1039,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDarkMage",
 		name = "Repairs",
 		description = "Swap 'Talk-to' with 'Repairs' for Dark Mage.",
-		position = 72,
+		position = 73,
 		group = "Talk-To"
 	)
 	default boolean swapDarkMage()
@@ -1039,7 +1051,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDecant",
 		name = "Decant",
 		description = "Swap 'Talk-to' with 'Decant' for Bob Barter and Murky Matt at the Grand Exchange.",
-		position = 73,
+		position = 74,
 		group = "Talk-To"
 	)
 	default boolean swapDecant()
@@ -1051,7 +1063,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapExchange",
 		name = "Exchange",
 		description = "Swap 'Talk-to' with 'Exchange' on various NPCs.<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight.",
-		position = 74,
+		position = 75,
 		group = "Talk-To"
 	)
 	default boolean swapExchange()
@@ -1063,7 +1075,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPickpocket",
 		name = "Pickpocket on H.A.M.",
 		description = "Swap 'Talk-to' with 'Pickpocket' on H.A.M members.",
-		position = 75,
+		position = 76,
 		group = "Talk-To"
 	)
 	default boolean swapPickpocket()
@@ -1075,7 +1087,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPay",
 		name = "Pay",
 		description = "Swap 'Talk-to' with 'Pay' on various NPCs.<br>Example: Elstan, Heskel, Fayeth.",
-		position = 76,
+		position = 77,
 		group = "Talk-To"
 	)
 	default boolean swapPay()
@@ -1087,7 +1099,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap 'Talk-to' with 'Teleport' for the Mage of Zamorak.",
-		position = 77,
+		position = 78,
 		group = "Talk-To"
 	)
 	default boolean swapAbyssTeleport()
@@ -1099,7 +1111,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap 'Talk-to' with 'Trade' on various NPCs.<br>Example: Shop keeper, Shop assistant.",
-		position = 78,
+		position = 79,
 		group = "Talk-To"
 	)
 	default boolean swapTrade()
@@ -1111,7 +1123,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTravel",
 		name = "Travel",
 		description = "Swap 'Talk-to' with 'Travel', 'Take-boat', 'Pay-fare', 'Charter' on various NPCs.<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember.",
-		position = 79,
+		position = 80,
 		group = "Talk-To"
 	)
 	default boolean swapTravel()
@@ -1123,7 +1135,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDream",
 		name = "Dream",
 		description = "Swap 'Talk-to' with 'Dream' for Dominic Onion.",
-		position = 80,
+		position = 81,
 		group = "Talk-To"
 	)
 	default boolean swapDream()
@@ -1135,7 +1147,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapStory",
 		name = "Story",
 		description = "Swap 'Talk-to' with 'Story' for Juna at Tears of Guthix.",
-		position = 81,
+		position = 82,
 		group = "Talk-To"
 	)
 	default boolean swapStory()
@@ -1147,7 +1159,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPlank",
 		name = "Buy Planks",
 		description = "Swap 'Talk-to' with 'Buy-planks' at the Lumber Yard.",
-		position = 82,
+		position = 83,
 		group = "Talk-To"
 	)
 	default boolean swapPlank()
@@ -1159,7 +1171,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapMetamorphosis",
 		name = "Metamorphosis",
 		description = "Swap 'Talk-to' with 'Metamorphosis' for Baby Chinchompa pet.",
-		position = 83,
+		position = 84,
 		group = "Talk-To"
 	)
 	default boolean swapMetamorphosis()
@@ -1171,7 +1183,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapEscort",
 		name = "Escort",
 		description = "Swap 'Talk-to' with 'Escort' for the Temple Trekking mini-game.",
-		position = 84,
+		position = 85,
 		group = "Talk-To"
 	)
 	default boolean swapEscort()
@@ -1185,7 +1197,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapFairyRing",
 		name = "Fairy Ring",
 		description = "Swap 'Zanaris' with 'Last-destination' or 'Configure' on Fairy rings.",
-		position = 85,
+		position = 86,
 		group = "Teleportation"
 	)
 	default boolean swapFairyRing()
@@ -1197,7 +1209,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "fairyring",
 		name = "Mode",
 		description = "",
-		position = 86,
+		position = 87,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapFairyRing"
@@ -1211,7 +1223,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapObelisk",
 		name = "Obelisk",
 		description = "Swap the options on wilderness obelisks between 'Activate', 'Set destination' or 'Teleport to destination'.",
-		position = 87,
+		position = 88,
 		group = "Teleportation"
 	)
 	default boolean swapObelisk()
@@ -1223,7 +1235,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "obelisk",
 		name = "Mode",
 		description = "",
-		position = 88,
+		position = 89,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapObelisk"
@@ -1237,7 +1249,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTeleportItem",
 		name = "Teleport Items",
 		description = "Swap 'Wear' or 'Wield' with 'Rub' or 'Teleport' on teleport items.<br>Example: Amulet of glory, Explorer's ring, Chronicle.",
-		position = 89,
+		position = 90,
 		group = "Teleportation"
 	)
 	default boolean swapTeleportItem()
@@ -1249,7 +1261,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapWildernessLever",
 		name = "Wilderness Lever",
 		description = "Swap the wilderness lever left click to be Edgeville/Ardougne.",
-		position = 90,
+		position = 91,
 		group = "Teleportation"
 	)
 	default boolean swapWildernessLever()
@@ -1261,7 +1273,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapNexus",
 		name = "Portal Nexus",
 		description = "Makes the teleport menu have priority over the left click destination on the portal nexus.",
-		position = 91,
+		position = 92,
 		group = "Teleportation"
 	)
 	default boolean swapNexus()
@@ -1273,7 +1285,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGamesNecklace",
 		name = "Swap Games Necklace",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Games Necklace.",
-		position = 92,
+		position = 93,
 		group = "Teleportation"
 	)
 	default boolean getGamesNecklace()
@@ -1285,7 +1297,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gamesNecklaceMode",
 		name = "Mode",
 		description = "",
-		position = 93,
+		position = 94,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGamesNecklace"
@@ -1299,7 +1311,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDuelingRing",
 		name = "Swap Dueling Ring",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Dueling.",
-		position = 94,
+		position = 95,
 		group = "Teleportation"
 	)
 	default boolean getDuelingRing()
@@ -1311,7 +1323,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "duelingRingMode",
 		name = "Mode",
 		description = "",
-		position = 95,
+		position = 96,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDuelingRing"
@@ -1325,7 +1337,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGlory",
 		name = "Swap Glory",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Amulet of Glory / Amulet of Eternal Glory.",
-		position = 96,
+		position = 97,
 		group = "Teleportation"
 	)
 	default boolean getGlory()
@@ -1337,7 +1349,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gloryMode",
 		name = "Mode",
 		description = "",
-		position = 97,
+		position = 98,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGlory"
@@ -1351,7 +1363,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSkill",
 		name = "Swap Skill",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Skills Necklace.",
-		position = 98,
+		position = 99,
 		group = "Teleportation"
 	)
 	default boolean getSkillsNecklace()
@@ -1363,7 +1375,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "skillsnecklacemode",
 		name = "Mode",
 		description = "",
-		position = 99,
+		position = 100,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapSkill"
@@ -1377,7 +1389,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPassage",
 		name = "Swap Passage",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Necklace of Passage.",
-		position = 100,
+		position = 101,
 		group = "Teleportation"
 	)
 	default boolean getNecklaceofPassage()
@@ -1389,7 +1401,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "necklaceofpassagemode",
 		name = "Mode",
 		description = "",
-		position = 101,
+		position = 102,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapPassage"
@@ -1403,7 +1415,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDigsite",
 		name = "Swap Digsite",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Digsite Pendant.",
-		position = 102,
+		position = 103,
 		group = "Teleportation"
 	)
 	default boolean getDigsitePendant()
@@ -1415,7 +1427,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "digsitependantmode",
 		name = "Mode",
 		description = "",
-		position = 103,
+		position = 104,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDigsite"
@@ -1429,7 +1441,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapCombat",
 		name = "Swap Combat",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Combat Bracelet.",
-		position = 104,
+		position = 105,
 		group = "Teleportation"
 	)
 	default boolean getCombatBracelet()
@@ -1441,7 +1453,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "combatbraceletmode",
 		name = "Mode",
 		description = "",
-		position = 105,
+		position = 106,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapCombat"
@@ -1455,7 +1467,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapburning",
 		name = "Swap Burning",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Burning Amulet.",
-		position = 106,
+		position = 107,
 		group = "Teleportation"
 	)
 	default boolean getBurningAmulet()
@@ -1467,7 +1479,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "burningamuletmode",
 		name = "Mode",
 		description = "",
-		position = 107,
+		position = 108,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapburning"
@@ -1481,7 +1493,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapxeric",
 		name = "Swap Xeric's",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Xeric's Talisman.",
-		position = 108,
+		position = 109,
 		group = "Teleportation"
 	)
 	default boolean getXericsTalisman()
@@ -1493,7 +1505,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "xericstalismanmode",
 		name = "Mode",
 		description = "",
-		position = 109,
+		position = 110,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapxeric"
@@ -1507,7 +1519,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapwealth",
 		name = "Swap Wealth",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Wealth.",
-		position = 110,
+		position = 111,
 		group = "Teleportation"
 	)
 	default boolean getRingofWealth()
@@ -1519,7 +1531,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "ringofwealthmode",
 		name = "Mode",
 		description = "",
-		position = 111,
+		position = 112,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapwealth"
@@ -1535,7 +1547,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideExamine",
 		name = "Hide Examine",
 		description = "Hides the 'Examine' option from the right click menu.",
-		position = 112,
+		position = 113,
 		group = "Right Click Options"
 	)
 	default boolean hideExamine()
@@ -1547,7 +1559,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideTradeWith",
 		name = "Hide Trade With",
 		description = "Hides the 'Trade with' option from the right click menu.",
-		position = 113,
+		position = 114,
 		group = "Right Click Options"
 	)
 	default boolean hideTradeWith()
@@ -1559,7 +1571,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideReport",
 		name = "Hide Report",
 		description = "Hides the 'Report' option from the right click menu.",
-		position = 114,
+		position = 115,
 		group = "Right Click Options"
 	)
 	default boolean hideReport()
@@ -1571,7 +1583,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideLookup",
 		name = "Hide Lookup",
 		description = "Hides the 'Lookup' option from the right click menu.",
-		position = 115,
+		position = 116,
 		group = "Right Click Options"
 	)
 	default boolean hideLookup()
@@ -1583,7 +1595,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideNet",
 		name = "Hide Net",
 		description = "Hides the 'Net' option from the right click menu.",
-		position = 116,
+		position = 117,
 		group = "Right Click Options"
 	)
 	default boolean hideNet()
@@ -1595,7 +1607,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideBait",
 		name = "Hide Bait",
 		description = "Hides the 'Bait' option from the right click menu.",
-		position = 117,
+		position = 118,
 		group = "Right Click Options"
 	)
 	default boolean hideBait()
@@ -1609,7 +1621,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyRunepouch",
 			name = "Hide Destroy on Rune Pouch",
 			description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
-			position = 118,
+			position = 119,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyRunepouch()
@@ -1621,7 +1633,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyCoalbag",
 			name = "Hide Destroy on Coal bag",
 			description = "Hides the 'Destroy' option when right clicking a Coal bag.",
-			position = 119,
+			position = 120,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyCoalbag()
@@ -1633,7 +1645,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyHerbsack",
 			name = "Hide Destroy on Herb sack",
 			description = "Hides the 'Destroy' option when right clicking a Herb sack.",
-			position = 120,
+			position = 121,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyHerbsack()
@@ -1645,7 +1657,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyBoltpouch",
 			name = "Hide Destroy on Bolt pouch",
 			description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
-			position = 121,
+			position = 122,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyBoltpouch()
@@ -1657,7 +1669,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDestroyGembag",
 			name = "Hide Destroy on Gem bag",
 			description = "Hides the 'Destroy' option when right clicking a Gem bag.",
-			position = 122,
+			position = 123,
 			group = "Untradeables"
 	)
 	default boolean hideDestroyGembag()
@@ -1669,7 +1681,7 @@ public interface MenuEntrySwapperConfig extends Config
 			keyName = "hideDropRunecraftingPouch",
 			name = "Hide Drop on RC pouches",
 			description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
-			position = 123,
+			position = 124,
 			group = "Untradeables"
 	)
 	default boolean hideDropRunecraftingPouch()
@@ -1683,7 +1695,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapImps",
 		name = "Impling Jars",
 		description = "Don't open implings if bank has a clue.",
-		position = 124,
+		position = 125,
 		group = "Miscellaneous"
 	)
 	default boolean swapImps()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -2,6 +2,7 @@
  * Copyright (c) 2018, Adam <Adam@sigterm.info>
  * Copyright (c) 2018, Kyle <https://github.com/kyleeld>
  * Copyright (c) 2018, lucouswin <https://github.com/lucouswin>
+ * Copyright (c) 2019 Infinitay <https://github.com/Infinitay>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -59,151 +60,151 @@ public interface MenuEntrySwapperConfig extends Config
 		position = 0,
 		group = "Banking"
 	)
-	default boolean shiftWithdrawal()
+	default boolean shiftBanking()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawOne",
+		keyName = "bankOne",
 		name = "Withdraw/Deposit One",
 		description = "",
 		position = 1,
 		group = "Banking"
 	)
-	default boolean getWithdrawOne()
+	default boolean getBankOne()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawOneItems",
+		keyName = "bankOneItems",
 		name = "Withdraw/Deposit One Item List",
 		description = "",
 		position = 2,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawOne"
+		unhide = "bankOne"
 	)
-	default String getWithdrawOneItems()
+	default String getBankOneItems()
 	{
 		return "";
 	}
 
 	@ConfigItem(
-		keyName = "withdrawFive",
+		keyName = "bankFive",
 		name = "Withdraw/Deposit Five",
 		description = "",
 		position = 3,
 		group = "Banking"
 	)
-	default boolean getWithdrawFive()
+	default boolean getBankFive()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawFiveItems",
+		keyName = "bankFiveItems",
 		name = "Withdraw/Deposit Five Item List",
 		description = "",
 		position = 4,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawFive"
+		unhide = "bankFive"
 	)
-	default String getWithdrawFiveItems()
+	default String getBankFiveItems()
 	{
 		return "";
 	}
 
 	@ConfigItem(
-		keyName = "withdrawTen",
+		keyName = "bankTen",
 		name = "Withdraw/Deposit Ten",
 		description = "",
 		position = 5,
 		group = "Banking"
 	)
-	default boolean getWithdrawTen()
+	default boolean getBankTen()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawTenItems",
+		keyName = "bankTenItems",
 		name = "Withdraw/Deposit Ten Item List",
 		description = "",
 		position = 6,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawTen"
+		unhide = "bankTen"
 	)
-	default String getWithdrawTenItems()
+	default String getBankTenItems()
 	{
 		return "";
 	}
 
 	@ConfigItem(
-		keyName = "withdrawX",
+		keyName = "bankX",
 		name = "Withdraw/Deposit X",
 		description = "",
 		position = 7,
 		group = "Banking"
 	)
-	default boolean getWithdrawX()
+	default boolean getBankX()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawXAmount",
+		keyName = "bankXAmount",
 		name = "Withdraw/Deposit X Amount",
 		description = "",
 		position = 8,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawX"
+		unhide = "bankX"
 	)
-	default String getWithdrawXAmount()
+	default String getBankXAmount()
 	{
 		return "";
 	}
 
 	@ConfigItem(
-		keyName = "withdrawXItems",
+		keyName = "bankXItems",
 		name = "Withdraw/Deposit X Item List",
 		description = "",
 		position = 9,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawX"
+		unhide = "bankX"
 	)
-	default String getWithdrawXItems()
+	default String getBankXItems()
 	{
 		return "";
 	}
 
 	@ConfigItem(
-		keyName = "withdrawAll",
+		keyName = "bankAll",
 		name = "Withdraw/Deposit All",
 		description = "",
 		position = 10,
 		group = "Banking"
 	)
-	default boolean getWithdrawAll()
+	default boolean getBankAll()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "withdrawAllItems",
+		keyName = "bankAllItems",
 		name = "Withdraw/Deposit All Item List",
 		description = "",
 		position = 11,
 		group = "Banking",
 		hidden = true,
-		unhide = "withdrawAll"
+		unhide = "bankAll"
 	)
-	default String getWithdrawAllItems()
+	default String getBankAllItems()
 	{
 		return "";
 	}
@@ -1618,11 +1619,11 @@ public interface MenuEntrySwapperConfig extends Config
 	//----------------------Untradeables---------------------------//
 
 	@ConfigItem(
-			keyName = "hideDestroyRunepouch",
-			name = "Hide Destroy on Rune Pouch",
-			description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
-			position = 119,
-			group = "Untradeables"
+		keyName = "hideDestroyRunepouch",
+		name = "Hide Destroy on Rune Pouch",
+		description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
+		position = 119,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyRunepouch()
 	{
@@ -1630,11 +1631,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyCoalbag",
-			name = "Hide Destroy on Coal bag",
-			description = "Hides the 'Destroy' option when right clicking a Coal bag.",
-			position = 120,
-			group = "Untradeables"
+		keyName = "hideDestroyCoalbag",
+		name = "Hide Destroy on Coal bag",
+		description = "Hides the 'Destroy' option when right clicking a Coal bag.",
+		position = 120,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyCoalbag()
 	{
@@ -1642,11 +1643,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyHerbsack",
-			name = "Hide Destroy on Herb sack",
-			description = "Hides the 'Destroy' option when right clicking a Herb sack.",
-			position = 121,
-			group = "Untradeables"
+		keyName = "hideDestroyHerbsack",
+		name = "Hide Destroy on Herb sack",
+		description = "Hides the 'Destroy' option when right clicking a Herb sack.",
+		position = 121,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyHerbsack()
 	{
@@ -1654,11 +1655,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyBoltpouch",
-			name = "Hide Destroy on Bolt pouch",
-			description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
-			position = 122,
-			group = "Untradeables"
+		keyName = "hideDestroyBoltpouch",
+		name = "Hide Destroy on Bolt pouch",
+		description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
+		position = 122,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyBoltpouch()
 	{
@@ -1666,11 +1667,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyGembag",
-			name = "Hide Destroy on Gem bag",
-			description = "Hides the 'Destroy' option when right clicking a Gem bag.",
-			position = 123,
-			group = "Untradeables"
+		keyName = "hideDestroyGembag",
+		name = "Hide Destroy on Gem bag",
+		description = "Hides the 'Destroy' option when right clicking a Gem bag.",
+		position = 123,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyGembag()
 	{
@@ -1678,11 +1679,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDropRunecraftingPouch",
-			name = "Hide Drop on RC pouches",
-			description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
-			position = 124,
-			group = "Untradeables"
+		keyName = "hideDropRunecraftingPouch",
+		name = "Hide Drop on RC pouches",
+		description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
+		position = 124,
+		group = "Untradeables"
 	)
 	default boolean hideDropRunecraftingPouch()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -32,7 +32,6 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Provides;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -605,10 +604,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			}
 		}
 
-		if ((option.contains("buy") || option.contains("value")) && Arrays.stream(entries).anyMatch(menuEntry ->
-		{
-			return menuEntry.getOption().toLowerCase().contains("buy");
-		}))
+		if (option.contains("buy"))
 		{
 			if (config.getSwapBuyOne() && !config.getBuyOneItems().equals(""))
 			{
@@ -654,10 +650,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				}
 			}
 		}
-		else if ((option.contains("sell") || option.contains("value")) && Arrays.stream(entries).anyMatch(menuEntry ->
-		{
-			return menuEntry.getOption().toLowerCase().contains("sell");
-		}))
+		else if (option.contains("sell"))
 		{
 			if (config.getSwapSellOne() && !config.getSellOneItems().equals(""))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -542,7 +542,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		final NPC hintArrowNpc = client.getHintArrowNpc();
 		entries = client.getMenuEntries();
 
-		if (option.contains("withdraw") || option.contains("deposit"))
+		if ((option.contains("withdraw") || option.contains("deposit")) && (config.shiftWithdrawal() && shiftModifier))
 		{
 			if (config.getWithdrawOne())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -612,7 +612,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Buy 1", option, target);
+						menuManager.addSwap("Value", target, "Buy 1", target, true, false);
 					}
 				}
 			}
@@ -623,7 +623,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Buy 5", option, target);
+						menuManager.addSwap("Value", target, "Buy 5", target, true, false);
 					}
 				}
 			}
@@ -634,7 +634,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Buy 10", option, target);
+						menuManager.addSwap("Value", target, "Buy 10", target, true, false);
 					}
 				}
 			}
@@ -645,7 +645,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Buy 50", option, target);
+						menuManager.addSwap("Value", target, "Buy 50", target, true, false);
 					}
 				}
 			}
@@ -658,7 +658,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Sell 1", option, target);
+						menuManager.addSwap("Value", target, "Sell 1", target, true, false);
 					}
 				}
 			}
@@ -669,7 +669,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Sell 5", option, target);
+						menuManager.addSwap("Value", target, "Sell 5", target, true, false);
 					}
 				}
 			}
@@ -680,7 +680,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Sell 10", option, target);
+						menuManager.addSwap("Value", target, "Sell 10", target, true, false);
 					}
 				}
 			}
@@ -691,10 +691,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 				{
 					if (target.equals(Text.standardize(item)))
 					{
-						swap(client, "Sell 50", option, target);
+						menuManager.addSwap("Value", target, "Sell 50", target, true, false);
 					}
 				}
 			}
+		} else if ((option.contains("buy") && (config.shiftShopping() && !shiftModifier))
+			|| option.contains("sell") && (config.shiftShopping() && !shiftModifier)) {
+			removeSwaps();
+			addSwaps();
 		}
 
 		if (config.getRemoveObjects() && !config.getRemovedObjects().equals(""))
@@ -1443,7 +1447,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removeSwaps("ring of wealth");
 		menuManager.removeSwaps("max cape");
 		menuManager.removeSwaps("quest point cape");
-		
+		menuManager.clearSwaps();
 	}
 
 	private void delete(int target)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -541,7 +541,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 		final NPC hintArrowNpc = client.getHintArrowNpc();
 		entries = client.getMenuEntries();
 
-		if ((option.contains("withdraw") || option.contains("deposit")) && (config.shiftWithdrawal() && shiftModifier))
+		if ((option.contains("withdraw") || option.contains("deposit")) &&
+			(!config.shiftWithdrawal() || config.shiftWithdrawal() && shiftModifier))
 		{
 			if (config.getWithdrawOne())
 			{
@@ -604,7 +605,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			}
 		}
 
-		if (option.contains("buy"))
+		if (option.contains("buy") && (!config.shiftShopping() || config.shiftShopping() && shiftModifier))
 		{
 			if (config.getSwapBuyOne() && !config.getBuyOneItems().equals(""))
 			{
@@ -650,7 +651,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				}
 			}
 		}
-		else if (option.contains("sell"))
+		else if (option.contains("sell") && (!config.shiftShopping() || config.shiftShopping() && shiftModifier))
 		{
 			if (config.getSwapSellOne() && !config.getSellOneItems().equals(""))
 			{
@@ -695,8 +696,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 					}
 				}
 			}
-		} else if ((option.contains("buy") && (config.shiftShopping() && !shiftModifier))
-			|| option.contains("sell") && (config.shiftShopping() && !shiftModifier)) {
+		}
+		else if ((option.contains("buy") && (config.shiftShopping() && !shiftModifier))
+			|| option.contains("sell") && (config.shiftShopping() && !shiftModifier))
+		{
 			menuManager.clearSwaps();
 			addSwaps();
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -199,7 +199,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		//todo re-enable when fixed.
 		/*loadConstructionIDs("");*/
 		loadCustomSwaps(""); // Removes all custom swaps
-		removeSwaps();
+		menuManager.clearSwaps();
 	}
 
 	@Subscribe
@@ -212,7 +212,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		//todo re-enable when fixed.
 
 		/*loadConstructionIDs(config.getConstructionItems());*/
-		removeSwaps();
+		menuManager.clearSwaps();
 		addSwaps();
 
 		if (!CONFIG_GROUP.equals(event.getGroup()))
@@ -697,7 +697,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 			}
 		} else if ((option.contains("buy") && (config.shiftShopping() && !shiftModifier))
 			|| option.contains("sell") && (config.shiftShopping() && !shiftModifier)) {
-			removeSwaps();
+			menuManager.clearSwaps();
 			addSwaps();
 		}
 
@@ -1429,25 +1429,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			menuManager.addSwap("remove", "quest point cape", config.questCapeMode().toString());
 		}
-	}
-
-	private void removeSwaps()
-	{
-		menuManager.removeSwaps("burning amulet");
-		menuManager.removeSwaps("combat bracelet");
-		menuManager.removeSwaps("games necklace");
-		menuManager.removeSwaps("ring of dueling");
-		menuManager.removeSwaps("amulet of glory");
-		menuManager.removeSwaps("amulet of eternal glory");
-		menuManager.removeSwaps("skills necklace");
-		menuManager.removeSwaps("necklace of passage");
-		menuManager.removeSwaps("digsite pendant");
-		menuManager.removeSwaps("slayer ring");
-		menuManager.removeSwaps("xeric's talisman");
-		menuManager.removeSwaps("ring of wealth");
-		menuManager.removeSwaps("max cape");
-		menuManager.removeSwaps("quest point cape");
-		menuManager.clearSwaps();
 	}
 
 	private void delete(int target)


### PR DESCRIPTION
- Only swap withdraw/deposit when holding shift
- Only swap buy/sell when holding shift
- Add method to clear all swaps `MenuManager#clearSwaps`
- Removed `MenuEntrySwapperPlugin#removeSwaps`, replaced with `MenuManager#clearSwaps`
- Update buy/sell swaps to swap with value `MenuEntry `to allow for one clicking
- Updated config for new changes, made banking/shopping config a little more clear/convenient 

I should note I haven't tested every single change, but I have tested burning amulet after the remove swap change, as well as shift-only banking/shopping and disabled shift-only banking/shopping.