### PR TITLE
additional PVP notification options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -153,5 +153,53 @@ public interface IdleNotifierConfig extends Config
 	{
 		return false;
 	}
+	
+	@ConfigItem(
+		keyName = "friends",
+		name = "Friends Notifer",
+		position = 10,
+		description = "Configures whether or not friends trigger a notification",
+		group = "PvP"
+	)
+	default boolean notifyFriends()
+	{
+		return false;
+	}
 
+	@ConfigItem(
+		keyName = "clan",
+		name = "Clan Notifier",
+		position = 11,
+		description = "Configures whether or not clan members trigger a notification",
+		group = "PvP"
+	)
+	default boolean notifyClan()
+	{
+		return false;
+	}
+
+
+	@ConfigItem(
+		keyName = "Beep",
+		name = "Warning Notification",
+		position = 11,
+		description = "Configures whether or not to trigger a beeping warning sound",
+		group = "PvP"
+	)
+	default boolean notifyWarningSound()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "Arrow",
+		name = "Draw Arrow",
+		position = 11,
+		description = "Configures whether or not to draw an arrow on new people who have spawned",
+		group = "PvP"
+	)
+	default boolean notifyArrow()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -399,7 +399,7 @@ public class IdleNotifierPlugin extends Plugin
 
 			if (config.notifyArrow())
 			{
-				WorldPoint hint = new WorldPoint(spawned.getWorldLocation().getX(),spawned.getWorldLocation().getY(),spawned.getWorldLocation().getPlane());
+				WorldPoint hint = new WorldPoint(spawned.getWorldLocation().getX(), spawned.getWorldLocation().getY(), spawned.getWorldLocation().getPlane());
 
 					client.setHintArrow(hint);
 			}
@@ -420,7 +420,7 @@ public class IdleNotifierPlugin extends Plugin
 				}
 
 				String chatMessage = new ChatMessageBuilder()
-						.append(spawned.getName() + " (" + spawnedLevel + ") - " + distance/128 + " tiles away! ")
+						.append(spawned.getName() + " (" + spawnedLevel + ") - " + distance / 128 + " tiles away! ")
 						.build();
 
 				chatMessageManager.queue(QueuedMessage.builder()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -122,6 +122,7 @@ import static net.runelite.api.AnimationID.WOODCUTTING_IRON;
 import static net.runelite.api.AnimationID.WOODCUTTING_MITHRIL;
 import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
 import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
+import net.runelite.api.ChatMessageType
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.coords.WorldPoint;
@@ -371,7 +372,7 @@ public class IdleNotifierPlugin extends Plugin
 			}
 		}
 		
-		Player spawned = playerSpawned.getPlayer();
+		Player spawned = event.getPlayer();
 		if (!config.notifyClan())
 		{
 			if (spawned.isClanMember())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -181,6 +181,9 @@ public class IdleNotifierPlugin extends Plugin
 
 	@Inject
 	private Client client;
+	
+	@Inject
+	private ChatMessageManager chatMessageManager;
 
 	@Inject
 	private IdleNotifierConfig config;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -122,7 +122,7 @@ import static net.runelite.api.AnimationID.WOODCUTTING_IRON;
 import static net.runelite.api.AnimationID.WOODCUTTING_MITHRIL;
 import static net.runelite.api.AnimationID.WOODCUTTING_RUNE;
 import static net.runelite.api.AnimationID.WOODCUTTING_STEEL;
-import net.runelite.api.ChatMessageType
+import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.coords.WorldPoint;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -73,6 +73,10 @@ public class IdleNotifierPluginTest
 	@Mock
 	@Bind
 	private Notifier notifier;
+	
+	@Mock
+	@Bind
+	ChatColorConfig chatColorConfig;
 
 	@Inject
 	private IdleNotifierPlugin plugin;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -76,7 +76,7 @@ public class IdleNotifierPluginTest
 	
 	@Mock
 	@Bind
-	ChatColorConfig chatColorConfig;
+	private ChatColorConfig chatColorConfig;
 
 	@Inject
 	private IdleNotifierPlugin plugin;


### PR DESCRIPTION
additional PVP notification options:

these only apply to the wilderness.

* Configures whether or not friends trigger a notification
* Configures whether or not clan members trigger a notification
* Configures whether or not to trigger a beeping warning sound
* Configures whether or not to draw an arrow on new people who have spawned

credit: LyzrdLite for the plugin, I just moved them to a better location.