### PR TITLE
additional PVP notification options

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierConfig.java
@@ -154,4 +154,52 @@ public interface IdleNotifierConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "friends",
+		name = "Friends Notifer",
+		position = 10,
+		description = "Configures whether or not friends trigger a notification",
+		group = "PvP"
+	)
+	default boolean notifyFriends()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "clan",
+		name = "Clan Notifier",
+		position = 11,
+		description = "Configures whether or not clan members trigger a notification",
+		group = "PvP"
+	)
+	default boolean notifyClan()
+	{
+		return false;
+	}
+
+
+	@ConfigItem(
+		keyName = "Beep",
+		name = "Warning Notification",
+		position = 11,
+		description = "Configures whether or not to trigger a beeping warning sound",
+		group = "PvP"
+	)
+	default boolean notifyWarningSound()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		keyName = "Arrow",
+		name = "Draw Arrow",
+		position = 11,
+		description = "Configures whether or not to draw an arrow on new people who have spawned",
+		group = "PvP"
+	)
+	default boolean notifyArrow()
+	{
+		return false;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPlugin.java
@@ -144,7 +144,7 @@ import net.runelite.api.events.GraphicChanged;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.PlayerSpawned;
-Import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.Widget;
 import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.Notifier;
 import net.runelite.client.chat.ChatMessageBuilder;

--- a/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/idlenotifier/IdleNotifierPluginTest.java
@@ -44,6 +44,7 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.client.Notifier;
+import net.runelite.client.config.ChatColorConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -85,6 +86,10 @@ public class IdleNotifierPluginTest
 
 	@Mock
 	private Player player;
+
+	@Mock
+	@Bind
+	private ChatColorConfig chatColorConfig;
 
 	@Before
 	public void setUp()


### PR DESCRIPTION
additional PVP notification options:
these only apply to the wilderness.
Configures whether or not friends trigger a notification
Configures whether or not clan members trigger a notification
Configures whether or not to trigger a beeping warning sound
Configures whether or not to draw an arrow on new people who have spawned
credit: LyzrdLite for the plugin, I just moved them to a better location.