### PR TITLE
Removed GPU requirement for clicking in detached/Oculus state

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSSceneMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSSceneMixin.java
@@ -286,6 +286,7 @@ public abstract class RSSceneMixin implements RSScene
 
 						if (client.getTileUpdateCount() == 0)
 						{
+							client.setCheckClick(false);
 							client.getCallbacks().drawScene();
 							return;
 						}
@@ -352,6 +353,7 @@ public abstract class RSSceneMixin implements RSScene
 
 						if (client.getTileUpdateCount() == 0)
 						{
+							client.setCheckClick(false);
 							client.getCallbacks().drawScene();
 							return;
 						}
@@ -360,6 +362,7 @@ public abstract class RSSceneMixin implements RSScene
 			}
 		}
 
+		client.setCheckClick(false);
 		client.getCallbacks().drawScene();
 	}
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSSceneMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSSceneMixin.java
@@ -286,11 +286,6 @@ public abstract class RSSceneMixin implements RSScene
 
 						if (client.getTileUpdateCount() == 0)
 						{
-							if (!isGpu && client.getOculusOrbState() != 0)
-							{
-								client.setEntitiesAtMouseCount(0);
-							}
-							client.setCheckClick(false);
 							client.getCallbacks().drawScene();
 							return;
 						}
@@ -357,11 +352,6 @@ public abstract class RSSceneMixin implements RSScene
 
 						if (client.getTileUpdateCount() == 0)
 						{
-							if (!isGpu && client.getOculusOrbState() != 0)
-							{
-								client.setEntitiesAtMouseCount(0);
-							}
-							client.setCheckClick(false);
 							client.getCallbacks().drawScene();
 							return;
 						}
@@ -370,11 +360,6 @@ public abstract class RSSceneMixin implements RSScene
 			}
 		}
 
-		if (!isGpu && client.getOculusOrbState() != 0)
-		{
-			client.setEntitiesAtMouseCount(0);
-		}
-		client.setCheckClick(false);
 		client.getCallbacks().drawScene();
 	}
 


### PR DESCRIPTION
GPU plugin was required to be enabled for clicking with a detached camera or Oculus orb, this fixes that