### PR TITLE
Pvpfix - attack/cast

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -404,27 +404,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 				}
 			}
 
-			int identifier = entry.getIdentifier();
-
-			Player[] players = client.getCachedPlayers();
-			Player player = null;
-
-			if (identifier >= 0 && identifier < players.length)
-			{
-				player = players[identifier];
-			}
-
-			if (player == null)
-			{
-				menu_entries.add(entry);
-				continue;
-			}
-
-			if ((option.contains("attack") || option.contains("cast")) && (player.isFriend() || player.isClanMember()))
-			{
-				continue;
-			}
-
 			menu_entries.add(entry);
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/AttackMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/AttackMode.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018, https://runelitepl.us
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.client.plugins.pvptools;
+
+public enum AttackMode
+{
+	CLAN("Clan"),
+	FRIENDS("Friends"),
+	BOTH("Both");
+
+	private final String name;
+
+	AttackMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsConfig.java
@@ -21,7 +21,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "countPlayers",
 		name = "Count Players",
 		description = "When in PvP zones, counts the attackable players in and not in player's CC",
-		position = 3
+		position = 0
 	)
 	default boolean countPlayers()
 	{
@@ -32,7 +32,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "countOverHeads",
 		name = "Count Enemy Overheads",
 		description = "Counts the number of each protection prayer attackable targets not in your CC are currently using",
-		position = 4
+		position = 1
 	)
 	default boolean countOverHeads()
 	{
@@ -43,7 +43,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "fallInHelper",
 		name = "Fall In Helper",
 		description = "Hides all non-friendly player entities other than the one that is attacking you.",
-		position = 5
+		position = 2
 	)
 	default boolean fallInHelper()
 	{
@@ -54,7 +54,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "hotkey",
 		name = "Fall In Hotkey",
 		description = "Turns the fall in helper on or off when you press this hotkey",
-		position = 6
+		position = 3
 	)
 	default Keybind hotkey()
 	{
@@ -65,7 +65,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "renderSelfHotkey",
 		name = "Render Self Hotkey",
 		description = "Toggles renderself when you press the hotkey",
-		position = 7
+		position = 4
 	)
 	default Keybind renderSelf()
 	{
@@ -73,10 +73,76 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "hideAttack",
+			name = "Hide attack",
+			description = "Hides the attack option for clanmates, friends, or both",
+			position = 5,
+			group = "Right-Click Attack Options"
+	)
+	default boolean hideAttack()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideAttackMode",
+			name = "Mode",
+			description = "",
+			position = 6,
+			group = "Right-Click Attack Options",
+			hidden = true,
+			unhide = "hideAttack"
+	)
+	default AttackMode hideAttackMode()
+	{
+		return AttackMode.FRIENDS;
+	}
+
+	@ConfigItem(
+			keyName = "hideCast",
+			name = "Hide cast",
+			description = "Hides the cast option for clanmates, friends, or both",
+			position = 7,
+			group = "Right-Click Attack Options"
+	)
+	default boolean hideCast()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "hideCastMode",
+			name = "Mode",
+			description = "",
+			position = 8,
+			group = "Right-Click Attack Options",
+			hidden = true,
+			unhide = "hideCast"
+	)
+	default AttackMode hideCastMode()
+	{
+		return AttackMode.FRIENDS;
+	}
+
+	@ConfigItem(
+			keyName = "hideCastIgnored",
+			name = "Ignored spells",
+			description = "Spells that should not be hidden from being cast, separated by a comma",
+			position = 9,
+			group = "Right-Click Attack Options",
+			hidden = true,
+			unhide = "hideCast"
+	)
+	default String hideCastIgnored()
+	{
+		return "cure other, energy transfer, heal other, vengeance other";
+	}
+
+	@ConfigItem(
 		keyName = "attackOptionsClan",
 		name = "Move CC Attack Option",
 		description = "Moves the attack option for people in the same CC",
-		position = 8,
+		position = 10,
 		group = "Right-Click Attack Options"
 	)
 	default boolean attackOptionsClan()
@@ -88,7 +154,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "attackOptionsFriend",
 		name = "Move Friend Attack Options",
 		description = "Moves the attack option for people on your friends list",
-		position = 9,
+		position = 11,
 		group = "Right-Click Attack Options"
 	)
 	default boolean attackOptionsFriend()
@@ -100,7 +166,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "levelRangeAttackOptions",
 		name = "Moves Other Attack Options",
 		description = "Moves the attack option for people that are outside your level range",
-		position = 10,
+		position = 12,
 		group = "Right-Click Attack Options"
 	)
 	default boolean levelRangeAttackOptions()
@@ -112,7 +178,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "riskCalculator",
 		name = "Risk Calculator",
 		description = "Enables a panel in the PvP Tools Panel that shows the players current risk",
-		position = 14
+		position = 13
 	)
 	default boolean riskCalculatorEnabled()
 	{
@@ -123,7 +189,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "missingPlayers",
 		name = "Missing CC Players",
 		description = "Adds a button to the PvP Tools panel that opens a window showing which CC members are not at the current players location",
-		position = 15
+		position = 14
 	)
 	default boolean missingPlayersEnabled()
 	{
@@ -134,7 +200,7 @@ public interface PvpToolsConfig extends Config
 		keyName = "currentPlayers",
 		name = "Current CC Players",
 		description = "Adds a button to the PvP Tools panel that opens a window showing which CC members currently at the players location",
-		position = 16
+		position = 15
 	)
 	default boolean currentPlayersEnabled()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsConfig.java
@@ -73,11 +73,11 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideAttack",
-			name = "Hide attack",
-			description = "Hides the attack option for clanmates, friends, or both",
-			position = 5,
-			group = "Right-Click Attack Options"
+		keyName = "hideAttack",
+		name = "Hide attack",
+		description = "Hides the attack option for clanmates, friends, or both",
+		position = 5,
+		group = "Right-Click Attack Options"
 	)
 	default boolean hideAttack()
 	{
@@ -85,13 +85,13 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideAttackMode",
-			name = "Mode",
-			description = "",
-			position = 6,
-			group = "Right-Click Attack Options",
-			hidden = true,
-			unhide = "hideAttack"
+		keyName = "hideAttackMode",
+		name = "Mode",
+		description = "",
+		position = 6,
+		group = "Right-Click Attack Options",
+		hidden = true,
+		unhide = "hideAttack"
 	)
 	default AttackMode hideAttackMode()
 	{
@@ -99,11 +99,11 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideCast",
-			name = "Hide cast",
-			description = "Hides the cast option for clanmates, friends, or both",
-			position = 7,
-			group = "Right-Click Attack Options"
+		keyName = "hideCast",
+		name = "Hide cast",
+		description = "Hides the cast option for clanmates, friends, or both",
+		position = 7,
+		group = "Right-Click Attack Options"
 	)
 	default boolean hideCast()
 	{
@@ -111,13 +111,13 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideCastMode",
-			name = "Mode",
-			description = "",
-			position = 8,
-			group = "Right-Click Attack Options",
-			hidden = true,
-			unhide = "hideCast"
+		keyName = "hideCastMode",
+		name = "Mode",
+		description = "",
+		position = 8,
+		group = "Right-Click Attack Options",
+		hidden = true,
+		unhide = "hideCast"
 	)
 	default AttackMode hideCastMode()
 	{
@@ -125,13 +125,13 @@ public interface PvpToolsConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideCastIgnored",
-			name = "Ignored spells",
-			description = "Spells that should not be hidden from being cast, separated by a comma",
-			position = 9,
-			group = "Right-Click Attack Options",
-			hidden = true,
-			unhide = "hideCast"
+		keyName = "hideCastIgnored",
+		name = "Ignored spells",
+		description = "Spells that should not be hidden from being cast, separated by a comma",
+		position = 9,
+		group = "Right-Click Attack Options",
+		hidden = true,
+		unhide = "hideCast"
 	)
 	default String hideCastIgnored()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -13,6 +13,7 @@ import com.google.inject.Provides;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.awt.image.BufferedImage;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -40,6 +41,7 @@ import net.runelite.api.events.FocusChanged;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuEntryAdded;
+import net.runelite.api.events.MenuOpened;
 import net.runelite.api.events.PlayerDespawned;
 import net.runelite.api.events.PlayerSpawned;
 import net.runelite.client.config.ConfigManager;
@@ -61,6 +63,7 @@ import net.runelite.client.util.PvPUtil;
 import static net.runelite.client.util.StackFormatter.quantityToRSDecimalStack;
 import net.runelite.client.util.Text;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 @PluginDescriptor(
 	name = "PvP Tools",
@@ -179,6 +182,8 @@ public class PvpToolsPlugin extends Plugin
 
 	private int[] overheadCount = new int[]{0, 0, 0};
 
+	private List ignoredSpells = new ArrayList();
+
 	private List<String> getMissingMembers()
 	{
 		CopyOnWriteArrayList<Player> ccMembers = ClanChatPlugin.getClanMembers();
@@ -263,6 +268,8 @@ public class PvpToolsPlugin extends Plugin
 		{
 			panel.currentPlayers.setVisible(true);
 		}
+
+		ignoredSpells = Arrays.asList(config.hideCastIgnored().toLowerCase().split("\\s*,\\s*"));
 	}
 
 	@Override
@@ -322,6 +329,9 @@ public class PvpToolsPlugin extends Plugin
 					{
 						panel.currentPlayers.setVisible(true);
 					}
+					break;
+				case "hideCastIgnored":
+					ignoredSpells = Arrays.asList(config.hideCastIgnored().toLowerCase().split("\\s*,\\s*"));
 					break;
 				default:
 					break;
@@ -428,6 +438,56 @@ public class PvpToolsPlugin extends Plugin
 				}
 			}
 		}
+	}
+
+	@Subscribe
+	public void onMenuOpened(MenuOpened event)
+	{
+		Player localPlayer = client.getLocalPlayer();
+
+		if (localPlayer == null)
+		{
+			return;
+		}
+
+		List<MenuEntry> menu = new ArrayList<>();
+
+		for (MenuEntry entry : event.getMenuEntries())
+		{
+			String option = Text.removeTags(entry.getOption()).toLowerCase();
+			String target = Text.removeTags(entry.getTarget()).toLowerCase();
+
+			int identifier = entry.getIdentifier();
+
+			Player[] players = client.getCachedPlayers();
+			Player player = null;
+
+			if (identifier >= 0 && identifier < players.length)
+			{
+				player = players[identifier];
+			}
+
+			if (player == null)
+			{
+				menu.add(entry);
+				continue;
+			}
+
+			if (option.contains("attack") && config.hideAttack() && shouldHide(config.hideAttackMode(), player))
+			{
+				continue;
+			}
+
+			else if (option.contains("cast") && config.hideCast() && shouldHide(config.hideCastMode(), player)
+					&& !ignoredSpells.contains(StringUtils.substringBefore(target, " ->")))
+			{
+				continue;
+			}
+
+			menu.add(entry);
+		}
+
+		client.setMenuEntries(menu.toArray(new MenuEntry[0]));
 	}
 
 	@Subscribe
@@ -668,6 +728,39 @@ public class PvpToolsPlugin extends Plugin
 			indexLocation++;
 		}
 		return null;
+	}
+
+	/**
+	 * Given an AttackMode, checks whether or not a player should be hidden.
+	 * @param mode The {@link AttackMode} the player should be checked against.
+	 * @param player The player that should be checked.
+	 * @return True if the player should be hidden, false otherwise.
+	 */
+	private boolean shouldHide(AttackMode mode, Player player)
+	{
+		switch (mode)
+		{
+			case CLAN:
+				if (player.isClanMember())
+				{
+					return true;
+				}
+				break;
+			case FRIENDS:
+				if (player.isFriend())
+				{
+					return true;
+				}
+				break;
+			case BOTH:
+				if (player.isClanMember() || player.isFriend())
+				{
+					return true;
+				}
+				break;
+		}
+
+		return false;
 	}
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pvptools/PvpToolsPlugin.java
@@ -428,11 +428,11 @@ public class PvpToolsPlugin extends Plugin
 				{
 					swap(pOptionToReplace);
 				}
-				if (config.attackOptionsClan() && player.isClanMember())
+				else if (config.attackOptionsClan() && player.isClanMember())
 				{
 					swap(pOptionToReplace);
 				}
-				if (config.levelRangeAttackOptions() && !PvPUtil.isAttackable(client, player))
+				else if (config.levelRangeAttackOptions() && !PvPUtil.isAttackable(client, player))
 				{
 					swap(pOptionToReplace);
 				}


### PR DESCRIPTION
Moves cast and attack being hidden from right click menu to pvptools from menuentryswapper and adds a config option. Also fixes bug when two swaps would interfere with each other.