### PR TITLE
Prevents Loot Tracker from causing a NullPointer Exception on first run

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -330,14 +330,16 @@ public class LootTrackerPlugin extends Plugin
 							lootRecords.addAll(RuneLiteAPI.GSON.fromJson(new FileReader(LOOT_RECORDS_FILE),
 								new TypeToken<ArrayList<LootRecord>>()
 								{ }.getType()));
-
 						}
-						catch (IOException e)
+						catch (IOException | NullPointerException e)
 						{
-							e.printStackTrace();
+							log.info("Couldn't load any locally stored loots.");
+						}
+						if (lootRecords.size() > 0)
+						{
+							log.info("Loaded {} locally stored loot records", lootRecords.size());
 						}
 					}
-
 
 					Collection<LootRecord> finalLootRecords = lootRecords;
 					clientThread.invokeLater(() ->


### PR DESCRIPTION
Adds info messages to replace NPE's created by being unable to load any local loot tracker records

Signed-off-by: PKLite <stonewall@pklite.xyz>