### PR TITLE
Updated Mouse Highlight Plugin - Fixed right click tool tips

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightConfig.java
@@ -85,4 +85,15 @@ public interface MouseHighlightConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "rightclickoptionTooltip",
+		name = "Right Click Option Tooltips",
+		description = "Whether or not tooltips are shown for options that right-click only."
+	)
+	default boolean isRightClickTooltipEnabled()
+	{
+		return true;
+	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/mousehighlight/MouseHighlightOverlay.java
@@ -75,9 +75,8 @@ class MouseHighlightOverlay extends Overlay
 		String option = menuEntry.getOption();
 		int type = menuEntry.getType();
 
-		if (type == MenuAction.RUNELITE_OVERLAY.getId() || type == MenuAction.EXAMINE_ITEM_BANK_EQ.getId())
+		if (shouldNotRenderMenuAction(type))
 		{
-			// These are always right click only
 			return null;
 		}
 
@@ -140,5 +139,16 @@ class MouseHighlightOverlay extends Overlay
 
 		tooltipManager.addFront(new Tooltip(option + (Strings.isNullOrEmpty(target) ? "" : " " + target)));
 		return null;
+	}
+
+	private boolean shouldNotRenderMenuAction(int type)
+	{
+		return type == MenuAction.RUNELITE_OVERLAY.getId()
+				|| (!config.isRightClickTooltipEnabled() && isMenuActionRightClickOnly(type));
+	}
+
+	private boolean isMenuActionRightClickOnly(int type)
+	{
+		return type == MenuAction.EXAMINE_ITEM_BANK_EQ.getId();
 	}
 }


### PR DESCRIPTION
A toggle for right-click-only option tooltips has been added to MouseHighlightConfig