### PR TITLE
Fix  #521 "Menu Entry Swapper - Claim Dynamite -Broken"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -938,6 +938,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "buy-plank", option, target, true);
 			}
 
+			if (config.claimDynamite() && target.equals("thirus"))
+			{
+				swap(client, "claim", option, target, true);
+			}
+
 			if (config.swapTrade())
 			{
 				swap(client, "trade", option, target, true);
@@ -948,11 +953,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 			if (config.claimSlime() && target.equals("robin"))
 			{
 				swap(client, "claim-slime", option, target, true);
-			}
-
-			if (config.claimDynamite() && target.contains("Thirus"))
-			{
-				swap(client, "claim-dynamite", option, target, true);
 			}
 
 			if (config.swapTravel())


### PR DESCRIPTION
Fixes  #521

Made the swap actually work and moved the claim swap up to be higher priority than the trade swap.