### PR TITLE
Adds option to hide orbs to learn to click plugin

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/learntoclick/LearnToClickConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/learntoclick/LearnToClickConfig.java
@@ -74,4 +74,15 @@ public interface LearnToClickConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		position = 5,
+		keyName = "hideOrbs",
+		name = "Hide Orbs",
+		description = "Completely hides the world map and special attack orbs"
+	)
+	default boolean hideOrbs()
+	{
+		return false;
+	}
 }


### PR DESCRIPTION
Adds the option to remove the world map and special attack orbs to the learn to click plugin.
Saw this requested in the discord a day or two ago

Signed-off-by: PKLite <stonewall@pklite.xyz>