### PR TITLE
Stopped default red names for non-clan members

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -281,7 +281,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 			{
 				color = config.getTeamMemberColor();
 			}
-			else if (!player.isClanMember() && !player.isFriend() && !PvPUtil.isAttackable(client, player))
+			else if (config.highlightNonClanMembers() && !player.isClanMember() && !player.isFriend() && !PvPUtil.isAttackable(client, player))
 			{
 				color = config.getNonClanMemberColor();
 			}


### PR DESCRIPTION
somehow this config check was missed