### PR TITLE
NPC Whitelist and Blacklist options for Loot Filter

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -93,6 +93,7 @@ public interface LootTrackerConfig extends Config
 	{
 		return true;
 	}
+
 	@ConfigItem(
 		keyName = "sortType",
 		name = "Sorting",
@@ -102,17 +103,20 @@ public interface LootTrackerConfig extends Config
 	{
 		return LootRecordSortType.TIMESTAMP;
 	}
+
 	@ConfigItem(
-		keyName =  "whitelistEnabled",
+		keyName = "whitelistEnabled",
 		name = "NPC Whitelist",
 		description = "Only track drops from specific NPCs",
 		position = 1,
 		group = "Filters",
 		disabledBy = "blacklistEnabled"
 	)
-	default boolean whitelistEnabled() {
+	default boolean whitelistEnabled()
+	{
 		return false;
 	}
+
 	@ConfigItem(
 		keyName = "getWhitelist",
 		name = "Whitelist",
@@ -126,17 +130,20 @@ public interface LootTrackerConfig extends Config
 	{
 		return "";
 	}
+
 	@ConfigItem(
-		keyName =  "blacklistEnabled",
+		keyName = "blacklistEnabled",
 		name = "NPC Blacklist",
 		description = "Track drops from all NPCs except for specified ones",
 		position = 3,
 		group = "Filters",
 		disabledBy = "whitelistEnabled"
 	)
-	default boolean blacklistEnabled() {
+	default boolean blacklistEnabled()
+	{
 		return false;
 	}
+
 	@ConfigItem(
 		keyName = "getBlacklist",
 		name = "Blacklist",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerConfig.java
@@ -35,7 +35,9 @@ public interface LootTrackerConfig extends Config
 	@ConfigItem(
 		keyName = "ignoredItems",
 		name = "Ignored items",
-		description = "Configures which items should be ignored when calculating loot prices."
+		description = "Configures which items should be ignored when calculating loot prices.",
+		position = 0,
+		group = "Filters"
 	)
 	default String getIgnoredItems()
 	{
@@ -100,5 +102,54 @@ public interface LootTrackerConfig extends Config
 	{
 		return LootRecordSortType.TIMESTAMP;
 	}
+	@ConfigItem(
+		keyName =  "whitelistEnabled",
+		name = "NPC Whitelist",
+		description = "Only track drops from specific NPCs",
+		position = 1,
+		group = "Filters",
+		disabledBy = "blacklistEnabled"
+	)
+	default boolean whitelistEnabled() {
+		return false;
+	}
+	@ConfigItem(
+		keyName = "getWhitelist",
+		name = "Whitelist",
+		description = "Comma-separated list of NPCs to track drops from",
+		position = 2,
+		group = "Filters",
+		hidden = true,
+		unhide = "whitelistEnabled"
+	)
+	default String getWhitelist()
+	{
+		return "";
+	}
+	@ConfigItem(
+		keyName =  "blacklistEnabled",
+		name = "NPC Blacklist",
+		description = "Track drops from all NPCs except for specified ones",
+		position = 3,
+		group = "Filters",
+		disabledBy = "whitelistEnabled"
+	)
+	default boolean blacklistEnabled() {
+		return false;
+	}
+	@ConfigItem(
+		keyName = "getBlacklist",
+		name = "Blacklist",
+		description = "Comma-separated list of NPCs to not track drops from",
+		position = 4,
+		group = "Filters",
+		hidden = true,
+		unhide = "blacklistEnabled"
+	)
+	default String getBlacklist()
+	{
+		return "";
+	}
+
 
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -104,7 +104,6 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.client.util.Text;
-import static net.runelite.client.util.Text.fromCSV;
 import net.runelite.http.api.RuneLiteAPI;
 import net.runelite.http.api.loottracker.GameItem;
 import net.runelite.http.api.loottracker.LootRecord;
@@ -261,7 +260,7 @@ public class LootTrackerPlugin extends Plugin
 		{
 			if (event.getKey().equals("ignoredItems"))
 			{
-				ignoredItems = fromCSV(config.getIgnoredItems());
+				ignoredItems = Text.fromCSV(config.getIgnoredItems());
 				SwingUtilities.invokeLater(panel::updateIgnoredRecords);
 			}
 			if (event.getKey().equals("sortType"))
@@ -276,7 +275,7 @@ public class LootTrackerPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		ignoredItems = fromCSV(config.getIgnoredItems());
+		ignoredItems = Text.fromCSV(config.getIgnoredItems());
 		panel = new LootTrackerPanel(this, itemManager, config);
 		spriteManager.getSpriteAsync(SpriteID.TAB_INVENTORY, 0, panel::loadHeaderIcon);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -104,6 +104,7 @@ import net.runelite.client.ui.NavigationButton;
 import net.runelite.client.util.ImageUtil;
 import net.runelite.client.util.StackFormatter;
 import net.runelite.client.util.Text;
+import static net.runelite.client.util.Text.fromCSV;
 import net.runelite.http.api.RuneLiteAPI;
 import net.runelite.http.api.loottracker.GameItem;
 import net.runelite.http.api.loottracker.LootRecord;
@@ -260,7 +261,7 @@ public class LootTrackerPlugin extends Plugin
 		{
 			if (event.getKey().equals("ignoredItems"))
 			{
-				ignoredItems = Text.fromCSV(config.getIgnoredItems());
+				ignoredItems = fromCSV(config.getIgnoredItems());
 				SwingUtilities.invokeLater(panel::updateIgnoredRecords);
 			}
 			if (event.getKey().equals("sortType"))
@@ -275,7 +276,7 @@ public class LootTrackerPlugin extends Plugin
 	@Override
 	protected void startUp() throws Exception
 	{
-		ignoredItems = Text.fromCSV(config.getIgnoredItems());
+		ignoredItems = fromCSV(config.getIgnoredItems());
 		panel = new LootTrackerPanel(this, itemManager, config);
 		spriteManager.getSpriteAsync(SpriteID.TAB_INVENTORY, 0, panel::loadHeaderIcon);
 
@@ -370,6 +371,21 @@ public class LootTrackerPlugin extends Plugin
 		final int combat = npc.getCombatLevel();
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		String localUsername = client.getLocalPlayer().getName();
+
+		if (config.whitelistEnabled()) {
+			final String configNpcs = config.getWhitelist().toLowerCase();
+			List<String> whitelist = Text.fromCSV(configNpcs);
+			if (!whitelist.contains(name.toLowerCase())) {
+				return;
+			}
+		} else if (config.blacklistEnabled()) {
+			final String configNpcs = config.getBlacklist().toLowerCase();
+			List<String> blacklist = Text.fromCSV(configNpcs);
+			if (blacklist.contains(name.toLowerCase())) {
+				return;
+			}
+		}
+
 		SwingUtilities.invokeLater(() -> panel.add(name, localUsername, combat, entries));
 		LootRecord lootRecord = new LootRecord( name, localUsername, LootRecordType.NPC,
 			toGameItems(items), Instant.now());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/loottracker/LootTrackerPlugin.java
@@ -323,13 +323,14 @@ public class LootTrackerPlugin extends Plugin
 						log.debug("Loaded {} remote data entries", lootRecords.size());
 					}
 
-					if (config.localPersistence() )
+					if (config.localPersistence())
 					{
 						try
 						{
 							lootRecords.addAll(RuneLiteAPI.GSON.fromJson(new FileReader(LOOT_RECORDS_FILE),
 								new TypeToken<ArrayList<LootRecord>>()
-								{ }.getType()));
+								{
+								}.getType()));
 						}
 						catch (IOException | NullPointerException e)
 						{
@@ -371,22 +372,27 @@ public class LootTrackerPlugin extends Plugin
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		String localUsername = client.getLocalPlayer().getName();
 
-		if (config.whitelistEnabled()) {
+		if (config.whitelistEnabled())
+		{
 			final String configNpcs = config.getWhitelist().toLowerCase();
 			List<String> whitelist = Text.fromCSV(configNpcs);
-			if (!whitelist.contains(name.toLowerCase())) {
+			if (!whitelist.contains(name.toLowerCase()))
+			{
 				return;
 			}
-		} else if (config.blacklistEnabled()) {
+		}
+		else if (config.blacklistEnabled())
+		{
 			final String configNpcs = config.getBlacklist().toLowerCase();
 			List<String> blacklist = Text.fromCSV(configNpcs);
-			if (blacklist.contains(name.toLowerCase())) {
+			if (blacklist.contains(name.toLowerCase()))
+			{
 				return;
 			}
 		}
 
 		SwingUtilities.invokeLater(() -> panel.add(name, localUsername, combat, entries));
-		LootRecord lootRecord = new LootRecord( name, localUsername, LootRecordType.NPC,
+		LootRecord lootRecord = new LootRecord(name, localUsername, LootRecordType.NPC,
 			toGameItems(items), Instant.now());
 
 		if (lootTrackerClient != null && config.saveLoot())
@@ -419,7 +425,7 @@ public class LootTrackerPlugin extends Plugin
 		final LootTrackerItem[] entries = buildEntries(stack(items));
 		String localUsername = client.getLocalPlayer().getName();
 		SwingUtilities.invokeLater(() -> panel.add(name, localUsername, combat, entries));
-		LootRecord lootRecord = new LootRecord( name, localUsername, LootRecordType.PLAYER,
+		LootRecord lootRecord = new LootRecord(name, localUsername, LootRecordType.PLAYER,
 			toGameItems(items), Instant.now());
 		if (lootTrackerClient != null && config.saveLoot())
 		{
@@ -614,7 +620,7 @@ public class LootTrackerPlugin extends Plugin
 					SwingUtilities.invokeLater(() -> panel.add(name, client.getLocalPlayer().getName(),
 						client.getLocalPlayer().getCombatLevel(), entries));
 					LootRecord lootRecord = new LootRecord(name, client.getLocalPlayer().getName(), LootRecordType.DEATH,
-						toGameItems(itemsLost),	Instant.now());
+						toGameItems(itemsLost), Instant.now());
 					if (lootTrackerClient != null && config.saveLoot())
 					{
 						lootTrackerClient.submit(lootRecord);
@@ -687,10 +693,10 @@ public class LootTrackerPlugin extends Plugin
 				.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
 		}
 
-			if (equipment != null)
-			{
-				Arrays.stream(equipment.getItems())
-					.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
+		if (equipment != null)
+		{
+			Arrays.stream(equipment.getItems())
+				.forEach(item -> inventorySnapshot.add(item.getId(), item.getQuantity()));
 		}
 	}
 


### PR DESCRIPTION
Suggested in #702. 
Whitelist NPCs, and only their drops will be tracked by the Loot Filter.
Blacklist NPCs, and all NPCs except for those on the blacklist will be tracked by the Loot Filter.