### PR TITLE
fixes #696 and adds the intended functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/pileindicators/PileIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pileindicators/PileIndicatorsConfig.java
@@ -35,10 +35,10 @@ import net.runelite.client.config.Stub;
 public interface PileIndicatorsConfig extends Config
 {
 	@ConfigItem(
-		keyName = "playerPilesStub",
-		name = "Player Piles",
-		description = "",
-		position = 0
+			keyName = "playerPilesStub",
+			name = "Player Piles",
+			description = "",
+			position = 0
 	)
 	default Stub playerPilesStub()
 	{
@@ -46,11 +46,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 1,
-		keyName = "enablePlayers",
-		name = "Enable Player Piling",
-		description = "Enable the option to highlight players when they pile.",
-		parent = "playerPilesStub"
+			position = 1,
+			keyName = "enablePlayers",
+			name = "Enable Player Piling",
+			description = "Enable the option to highlight players when they pile.",
+			parent = "playerPilesStub"
 	)
 	default boolean enablePlayers()
 	{
@@ -58,11 +58,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 2,
-		keyName = "wildyOnlyPlayer",
-		name = "Wilderness Only",
-		description = "Show player piling only when in the Wilderness.",
-		parent = "playerPilesStub"
+			position = 2,
+			keyName = "wildyOnlyPlayer",
+			name = "Wilderness Only",
+			description = "Show player piling only when in the Wilderness.",
+			parent = "playerPilesStub"
 	)
 	default boolean wildyOnlyPlayer()
 	{
@@ -70,22 +70,22 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
-		keyName = "playerPileColor",
-		name = "Player Pile Color",
-		description = "Color used for player piles.",
-		parent = "playerPilesStub"
+			position = 3,
+			keyName = "playerPileColor",
+			name = "Player Pile Color",
+			description = "Color used for player piles.",
+			parent = "playerPilesStub"
 	)
 	default Color playerPileColor()
 	{
 		return Color.RED;
 	}
-	
+
 	@ConfigItem(
-		keyName = "npcPilesStub",
-		name = "NPC Piles",
-		description = "",
-		position = 4
+			keyName = "npcPilesStub",
+			name = "NPC Piles",
+			description = "",
+			position = 4
 	)
 	default Stub npcPilesStub()
 	{
@@ -93,11 +93,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
-		keyName = "enableNPCS",
-		name = "Enable NPC Piling",
-		description = "Enable the option to highlight NPCs when they pile.",
-		parent = "npcPilesStub"
+			position = 5,
+			keyName = "enableNPCS",
+			name = "Enable NPC Piling",
+			description = "Enable the option to highlight NPCs when they pile.",
+			parent = "npcPilesStub"
 	)
 	default boolean enableNPCS()
 	{
@@ -105,11 +105,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
-		keyName = "npcPileColor",
-		name = "NPC Pile Color",
-		description = "Color used for NPC piles.",
-		parent = "npcPilesStub"
+			position = 6,
+			keyName = "npcPileColor",
+			name = "NPC Pile Color",
+			description = "Color used for NPC piles.",
+			parent = "npcPilesStub"
 	)
 	default Color npcPileColor()
 	{
@@ -117,10 +117,10 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "mixedPilesStub",
-		name = "Mixed Piles",
-		description = "",
-		position = 7
+			keyName = "mixedPilesStub",
+			name = "Mixed Piles",
+			description = "",
+			position = 7
 	)
 	default Stub mixedPilesStub()
 	{
@@ -128,11 +128,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
-		keyName = "mixedPileColor",
-		name = "Mixed Pile Color",
-		description = "Color used for mixed piles.",
-		parent = "mixedPilesStub"
+			position = 8,
+			keyName = "mixedPileColor",
+			name = "Mixed Pile Color",
+			description = "Color used for mixed piles.",
+			parent = "mixedPilesStub"
 	)
 	default Color mixedPileColor()
 	{
@@ -140,10 +140,10 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "pilesSizeStub",
-		name = "Pile size",
-		description = "",
-		position = 9
+			keyName = "pilesSizeStub",
+			name = "Pile size",
+			description = "",
+			position = 9
 	)
 	default Stub pilesSizeStub()
 	{
@@ -151,14 +151,14 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@Range(
-		min = 2
+			min = 2
 	)
 	@ConfigItem(
-		position = 10,
-		keyName = "minimumPileSize",
-		name = "Minimum Pile Size",
-		description = "Any pile under this size will not show up. (Minimum: 2)",
-		parent = "pilesSizeStub"
+			position = 10,
+			keyName = "minimumPileSize",
+			name = "Minimum Pile Size",
+			description = "Any pile under this size will not show up. (Minimum: 2)",
+			parent = "pilesSizeStub"
 	)
 	default int minimumPileSize()
 	{
@@ -166,10 +166,10 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "miscellaneousStub",
-		name = "Miscellaneous",
-		description = "",
-		position = 11
+			keyName = "miscellaneousStub",
+			name = "Miscellaneous",
+			description = "",
+			position = 11
 	)
 	default Stub miscellaneousStub()
 	{
@@ -177,11 +177,11 @@ public interface PileIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 12,
-		keyName = "numberOnly",
-		name = "Display Number Only",
-		description = "Shorten \"PILE SIZE: 1\" to \"1\"",
-		parent = "miscellaneousStub"
+			position = 12,
+			keyName = "numberOnly",
+			name = "Display Number Only",
+			description = "Shorten \"PILE SIZE: 1\" to \"1\"",
+			parent = "miscellaneousStub"
 	)
 	default boolean numberOnly()
 	{
@@ -190,22 +190,24 @@ public interface PileIndicatorsConfig extends Config
 
 	@ConfigItem(
 			position = 13,
-			keyName = "drawPileHull",
-			name = "Draws the hull of the pile.",
-			description = "Draws the hull of the pile for best visibility."
+			keyName = "drawPileTile",
+			name = "Draw Pile Tile",
+			description = "Draws the tile of the pile for best visibility.",
+			parent = "miscellaneousStub"
 	)
-	default boolean drawPileHull()
+	default boolean drawPileTile()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(
 			position = 14,
-			keyName = "highlightPile",
-			name = "Highlight Pile",
-			description = "Highlights Pile Onscreen"
+			keyName = "drawPileHull",
+			name = "Draw Pile Convex Hull",
+			description = "Draws the hull of the pile for best visibility.",
+			parent = "miscellaneousStub"
 	)
-	default boolean highlightPile()
+	default boolean drawPileHull()
 	{
 		return false;
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/pileindicators/PileIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pileindicators/PileIndicatorsPlugin.java
@@ -27,10 +27,12 @@ package net.runelite.client.plugins.pileindicators;
 import com.google.inject.Binder;
 import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.*;
-import net.runelite.api.events.GameTick;
+import net.runelite.api.Actor;
+import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.Player;
+import net.runelite.api.Varbits;
 import net.runelite.client.config.ConfigManager;
-import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
@@ -40,15 +42,13 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.awt.*;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
 
 @PluginDescriptor(
-	name = "Pile Indicators",
-	description = "Highlight and count how many npcs/players are stacked on each other.",
-	tags = {"overlay", "pile", "stack", "pvp", "pvm", "pve"},
-	type = PluginType.UTILITY,
-	enabledByDefault = false
+		name = "Pile Indicators",
+		description = "Highlight and count how many npcs/players are stacked on each other.",
+		tags = {"overlay", "pile", "stack", "pvp", "pvm", "pve"},
+		type = PluginType.UTILITY,
+		enabledByDefault = false
 )
 
 @Singleton
@@ -67,9 +67,6 @@ public class PileIndicatorsPlugin extends Plugin
 
 	@Inject
 	private PileIndicatorsOverlay overlay;
-
-	private List<String> pileList;
-	private ArrayList<String> callers = new ArrayList<>();
 
 	@Provides
 	PileIndicatorsConfig provideConfig(ConfigManager configManager)
@@ -92,35 +89,6 @@ public class PileIndicatorsPlugin extends Plugin
 	protected void shutDown() throws Exception
 	{
 		overlayManager.remove(overlay);
-	}
-
-	@Subscribe
-	public void onGameTick(GameTick gameTick)
-	{
-		if (config.highlightPile() && callers != null)
-		{
-			for (Player p : client.getPlayers())
-			{
-				for (String name : callers)
-				{
-					Actor pile;
-					String finalName = name.toLowerCase().replace("_", " ");
-					if (p.getName().toLowerCase().replace("_", " ").equals(finalName))
-					{
-						pile = p.getInteracting();
-						if (pile != null)
-						{
-							pileList.set(callers.indexOf(name), pile.getName());
-							//pileList.add(pile.getName());
-						}
-						else
-						{
-							pileList.set(callers.indexOf(name), "");
-						}
-					}
-				}
-			}
-		}
 	}
 
 	protected ArrayList<ArrayList<Actor>> getStacks()
@@ -193,15 +161,6 @@ public class PileIndicatorsPlugin extends Plugin
 				return config.mixedPileColor();
 		}
 		return null;
-	}
-
-	boolean isPile(Player player)
-	{
-		if (Objects.nonNull(pileList) && pileList.size() > 0)
-		{
-			return pileList.contains(player.getName());
-		}
-		return false;
 	}
 
 	protected PileType getPileType(ArrayList<Actor> pile)


### PR DESCRIPTION
removed all the player piles code that was slapped into the plugin causing travis to break and re-wrote the intended functionality (convex hull check, and text to show if its a player/npc/mixed pile)

some slight cleanup as well