### PR TITLE
Ignore comment lines on custom menu entry swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1309,7 +1309,17 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (!Strings.isNullOrEmpty(config))
 		{
-			Map<String, String> split = NEWLINE_SPLITTER.withKeyValueSeparator(':').split(config);
+			StringBuilder sb = new StringBuilder();
+
+			for (String str : config.split("\n"))
+			{
+				if (!str.startsWith("//"))
+				{
+					sb.append(str + "\n");
+				}
+			}
+
+			Map<String, String> split = NEWLINE_SPLITTER.withKeyValueSeparator(':').split(sb);
 
 			for (Map.Entry<String, String> entry : split.entrySet())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/Parse.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/Parse.java
@@ -32,12 +32,22 @@ public class Parse
 	{
 		try
 		{
+			StringBuilder sb = new StringBuilder();
+
+			for (String str : value.split("\n"))
+			{
+				if (!str.startsWith("//"))
+				{
+					sb.append(str + "\n");
+				}
+			}
+
 			Splitter NEWLINE_SPLITTER = Splitter
 				.on("\n")
 				.omitEmptyStrings()
 				.trimResults();
 
-			NEWLINE_SPLITTER.withKeyValueSeparator(':').split(value);
+			NEWLINE_SPLITTER.withKeyValueSeparator(':').split(sb);
 			return true;
 		}
 		catch (IllegalArgumentException ex)


### PR DESCRIPTION
Any line that starts with // will be ignored, giving you the ability to categorize your custom swaps.

![alt text](https://i.gyazo.com/09fe3443ac466ddbc7f7e691aae18bdf.png)