### PR TITLE
Updated menu swapper

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -1135,6 +1135,18 @@ public interface MenuEntrySwapperConfig extends Config
 		return false;
 	}
 
+	@ConfigItem(
+		keyName = "swapEnchant",
+		name = "Enchant",
+		description = "Swap Talk-to with Enchant for Eluned",
+		position = 82,
+		group = "Talk-To"
+	)
+	default boolean swapEnchant()
+	{
+		return true;
+	}
+
 	//------------------------------------------------------------//
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -47,6 +47,7 @@ import net.runelite.client.plugins.menuentryswapper.util.SkillsNecklaceMode;
 import net.runelite.client.plugins.menuentryswapper.util.SlayerRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.XericsTalismanMode;
 import net.runelite.client.plugins.menuentryswapper.util.teleEquippedMode;
+import net.runelite.client.plugins.menuentryswapper.util.CharterOption;
 
 
 @ConfigGroup("menuentryswapper")
@@ -1644,6 +1645,18 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapImps()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+		keyName = "charterOption",
+		name = "Trader Crew",
+		description = "Configure whether you want Charter or Trade to be the first option of Trader Crewmembers.",
+		position = 133,
+		group = "Miscellaneous"
+	)
+	default CharterOption charterOption()
+	{
+		return CharterOption.TRADE;
 	}
 
 	//------------------------------------------------------------//

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -46,7 +46,7 @@ import net.runelite.client.plugins.menuentryswapper.util.RingOfWealthMode;
 import net.runelite.client.plugins.menuentryswapper.util.SkillsNecklaceMode;
 import net.runelite.client.plugins.menuentryswapper.util.SlayerRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.XericsTalismanMode;
-
+import net.runelite.client.plugins.menuentryswapper.util.teleEquippedMode;
 
 
 @ConfigGroup("menuentryswapper")
@@ -211,6 +211,32 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "teleEquippedCape",
+			name = "Teleport Equipped Cape",
+			description = "Makes Teleport/Tele to POH the left click option on equip screen",
+			position = 11,
+			group = "Equipment swapper"
+	)
+	default boolean teleEquippedCape()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = "telecapeMode",
+			name = "ModeTeleCape",
+			description = "",
+			position = 12,
+			group = "Equipment swapper",
+			hidden = true,
+			unhide = "teleEquippedCape"
+	)
+	default teleEquippedMode telecapeMode()
+	{
+		return teleEquippedMode.TELEPORT;
+	}
+
+	@ConfigItem(
 		keyName = "maxMode",
 		name = "Mode",
 		description = "",
@@ -347,6 +373,16 @@ public interface MenuEntrySwapperConfig extends Config
 		group = "Miscellaneous"
 	)
 	default boolean shiftClickCustomization()
+	{
+		return true;
+	}
+
+	@ConfigItem(
+			keyName = "swapCoalBag",
+			name = "Swap Coal Bag Empty",
+			description = "Makes Empty the left click option when in a bank"
+	)
+	default boolean swapCoalBag()
 	{
 		return true;
 	}
@@ -964,13 +1000,13 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "swapBanker",
-		name = "Bank",
-		description = "Swap 'Talk-to' with 'Bank' on Bank NPCs.<br>Example: Banker.",
+		keyName = "swapBankExchange",
+		name = "Bank/Exchange",
+		description = "Swap Talk-to with Bank or Exchange on NPC<br>Example: Banker, Grand Exchange Clerk, Tool Leprechaun, Void Knight",
 		position = 67,
 		group = "Talk-To"
 	)
-	default boolean swapBank()
+	default boolean swapBankExchange()
 	{
 		return true;
 	}
@@ -987,70 +1023,23 @@ public interface MenuEntrySwapperConfig extends Config
 		return true;
 	}
 
-	@ConfigItem(
-		keyName = "claimDynamite",
-		name = "Claim Dynamite",
-		description = "Swap 'Talk-to' with 'Claim Dynamite' on Thirus.",
-		position = 69,
-		group = "Talk-To"
-	)
-	default boolean claimDynamite()
-	{
-		return true;
-	}
 
 	@ConfigItem(
-		keyName = "claimSlime",
-		name = "Claim Slime",
-		description = "Swap 'Talk-to' with 'Claim Slime' from Morytania diaries.",
-		position = 70,
-		group = "Talk-To"
-	)
-	default boolean claimSlime()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "swapDarkMage",
-		name = "Repairs",
-		description = "Swap 'Talk-to' with 'Repairs' for Dark Mage.",
-		position = 71,
-		group = "Talk-To"
-	)
-	default boolean swapDarkMage()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "swapDecant",
-		name = "Decant",
-		description = "Swap 'Talk-to' with 'Decant' for Bob Barter and Murky Matt at the Grand Exchange.",
+		keyName = "swapInteract",
+		name = "Interact",
+		description = "Swap options for generic interactions on NPCs<br>Example: Decant for Bob Barter, Repairs for Dark Mage, Claim Slime for Robin, Claim Dynamite",
 		position = 72,
 		group = "Talk-To"
 	)
-	default boolean swapDecant()
+	default boolean swapInteract()
 	{
 		return false;
 	}
 
 	@ConfigItem(
-		keyName = "swapExchange",
-		name = "Exchange",
-		description = "Swap 'Talk-to' with 'Exchange' on various NPCs.<br>Example: Grand Exchange Clerk, Tool Leprechaun, Void Knight.",
-		position = 73,
-		group = "Talk-To"
-	)
-	default boolean swapExchange()
-	{
-		return true;
-	}
-
-	@ConfigItem(
 		keyName = "swapPickpocket",
-		name = "Pickpocket on H.A.M.",
-		description = "Swap 'Talk-to' with 'Pickpocket' on H.A.M members.",
+		name = "Pickpocket",
+		description = "Swap Talk-to with Pickpocket on NPC<br>Example: Man, Woman",
 		position = 74,
 		group = "Talk-To"
 	)
@@ -1108,25 +1097,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "swapDream",
-		name = "Dream",
-		description = "Swap 'Talk-to' with 'Dream' for Dominic Onion.",
-		position = 79,
-		group = "Talk-To"
+			keyName = "swapMinigame",
+			name = "Minigames",
+			description = "Swap Talk-to with Start-Minigame, Story, Dream on NPC<br>Example: Guardian mummy, Juna, Dominic Onion"
 	)
-	default boolean swapDream()
-	{
-		return true;
-	}
-
-	@ConfigItem(
-		keyName = "swapStory",
-		name = "Story",
-		description = "Swap 'Talk-to' with 'Story' for Juna at Tears of Guthix.",
-		position = 80,
-		group = "Talk-To"
-	)
-	default boolean swapStory()
+	default boolean swapMinigame()
 	{
 		return true;
 	}
@@ -1153,18 +1128,6 @@ public interface MenuEntrySwapperConfig extends Config
 	default boolean swapMetamorphosis()
 	{
 		return false;
-	}
-
-	@ConfigItem(
-		keyName = "swapEscort",
-		name = "Escort",
-		description = "Swap 'Talk-to' with 'Escort' for the Temple Trekking mini-game.",
-		position = 83,
-		group = "Talk-To"
-	)
-	default boolean swapEscort()
-	{
-		return true;
 	}
 
 	//------------------------------------------------------------//

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperConfig.java
@@ -211,11 +211,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "teleEquippedCape",
-			name = "Teleport Equipped Cape",
-			description = "Makes Teleport/Tele to POH the left click option on equip screen",
-			position = 11,
-			group = "Equipment swapper"
+		keyName = "teleEquippedCape",
+		name = "Teleport Equipped Cape",
+		description = "Makes Teleport/Tele to POH the left click option on equip screen",
+		position = 12,
+		group = "Equipment swapper"
 	)
 	default boolean teleEquippedCape()
 	{
@@ -223,13 +223,13 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "telecapeMode",
-			name = "ModeTeleCape",
-			description = "",
-			position = 12,
-			group = "Equipment swapper",
-			hidden = true,
-			unhide = "teleEquippedCape"
+		keyName = "telecapeMode",
+		name = "ModeTeleCape",
+		description = "",
+		position = 13,
+		group = "Equipment swapper",
+		hidden = true,
+		unhide = "teleEquippedCape"
 	)
 	default teleEquippedMode telecapeMode()
 	{
@@ -240,7 +240,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "maxMode",
 		name = "Mode",
 		description = "",
-		position = 12,
+		position = 14,
 		group = "Equipment swapper",
 		hidden = true,
 		unhide = "swapMax"
@@ -254,7 +254,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapArdougneCape",
 		name = "Swap Ardougne Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 13,
+		position = 15,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapArdougneCape()
@@ -266,7 +266,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapConstructionCape",
 		name = "Swap Construction Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 14,
+		position = 16,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapConstructionCape()
@@ -278,7 +278,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapCraftingCape",
 		name = "Swap Crafting Cape",
 		description = "Enables swapping of 'Teleport' and 'Wear'.",
-		position = 15,
+		position = 17,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapCraftingCape()
@@ -290,7 +290,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapMagicCape",
 		name = "Swap Magic Cape",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
-		position = 16,
+		position = 18,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapMagicCape()
@@ -302,7 +302,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapExplorersRing",
 		name = "Swap Explorer's Ring",
 		description = "Enables swapping of 'Spellbook' and 'Wear'.",
-		position = 17,
+		position = 19,
 		group = "Equipment swapper"
 	)
 	default boolean getSwapExplorersRing()
@@ -314,7 +314,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAdmire",
 		name = "Admire",
 		description = "Swap 'Admire' with 'Teleport', 'Spellbook' and 'Perks' (max cape) for mounted skill capes.",
-		position = 18,
+		position = 20,
 		group = "Equipment swapper"
 	)
 	default boolean swapAdmire()
@@ -326,7 +326,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapQuestCape",
 		name = "Swap Quest Cape",
 		description = "Enables swapping Quest cape options in worn interface.",
-		position = 19,
+		position = 21,
 		group = "Equipment swapper"
 	)
 	default boolean swapQuestCape()
@@ -338,7 +338,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "questCapeMode",
 		name = "Mode",
 		description = "",
-		position = 20,
+		position = 22,
 		group = "Equipment swapper",
 		hidden = true,
 		unhide = "swapQuestCape"
@@ -354,7 +354,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "customSwaps",
 		name = "Custom Swaps",
 		description = "Add custom swaps here, 1 per line. Syntax: option, target : option, target<br>Note that the first entry should be the left click one!",
-		position = 19,
+		position = 23,
 		group = "Miscellaneous",
 		parse = true,
 		clazz = Parse.class,
@@ -369,7 +369,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "shiftClickCustomization",
 		name = "Customizable Shift-click",
 		description = "Allows customization of shift-clicks on items.",
-		position = 20,
+		position = 24,
 		group = "Miscellaneous"
 	)
 	default boolean shiftClickCustomization()
@@ -378,9 +378,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "swapCoalBag",
-			name = "Swap Coal Bag Empty",
-			description = "Makes Empty the left click option when in a bank"
+		keyName = "swapCoalBag",
+		name = "Swap Coal Bag Empty",
+		description = "Makes Empty the left click option when in a bank",
+		position = 25,
+		group = "Miscellaneous"
 	)
 	default boolean swapCoalBag()
 	{
@@ -391,7 +393,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBirdhouseEmpty",
 		name = "Birdhouse",
 		description = "Swap 'Interact' with 'Empty' for birdhouses on Fossil Island.",
-		position = 21,
+		position = 26,
 		group = "Miscellaneous"
 	)
 	default boolean swapBirdhouseEmpty()
@@ -403,7 +405,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBones",
 		name = "Bury",
 		description = "Swap 'Bury' with 'Use' on Bones.",
-		position = 22,
+		position = 27,
 		group = "Miscellaneous"
 	)
 	default boolean swapBones()
@@ -415,7 +417,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapChase",
 		name = "Chase",
 		description = "Allows to left click your cat to chase rats.",
-		position = 23,
+		position = 28,
 		group = "Miscellaneous"
 	)
 	default boolean swapChase()
@@ -427,7 +429,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHarpoon",
 		name = "Harpoon",
 		description = "Swap 'Cage', 'Big Net' with 'Harpoon' on Fishing spots.",
-		position = 24,
+		position = 29,
 		group = "Miscellaneous"
 	)
 	default boolean swapHarpoon()
@@ -439,7 +441,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapOccult",
 		name = "Occult Altar",
 		description = "Swap 'Venerate' with 'Ancient', 'Lunar', or 'Arceuus' on an Altar of the Occult.",
-		position = 25,
+		position = 30,
 		group = "Miscellaneous"
 	)
 	default boolean swapOccult()
@@ -451,7 +453,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "occultalter",
 		name = "Mode",
 		description = "",
-		position = 26,
+		position = 31,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "swapOccult"
@@ -465,7 +467,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHomePortal",
 		name = "Home",
 		description = "Swap 'Enter' with 'Home', 'Build' or 'Friend's house' on Portal.",
-		position = 27,
+		position = 32,
 		group = "Miscellaneous"
 	)
 	default boolean swapHomePortal()
@@ -477,7 +479,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "home",
 		name = "Mode",
 		description = "",
-		position = 28,
+		position = 33,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "swapHomePortal"
@@ -491,7 +493,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPrivate",
 		name = "Private",
 		description = "Swap 'Shared' with 'Private' on the Chambers of Xeric storage units.",
-		position = 29,
+		position = 34,
 		group = "Miscellaneous"
 	)
 	default boolean swapPrivate()
@@ -503,7 +505,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPick",
 		name = "Pick",
 		description = "Swap 'Pick' with 'Pick-lots' of the Gourd tree in the Chambers of Xeric.",
-		position = 30,
+		position = 35,
 		group = "Miscellaneous"
 	)
 	default boolean swapPick()
@@ -515,7 +517,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapQuick",
 		name = "Quick Pass/Open/Start/Travel",
 		description = "Swap 'Pass' with 'Quick-Pass', 'Open' with 'Quick-Open', 'Ring' with 'Quick-Start' and 'Talk-to' with 'Quick-Travel'.",
-		position = 31,
+		position = 36,
 		group = "Miscellaneous"
 	)
 	default boolean swapQuick()
@@ -527,7 +529,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBoxTrap",
 		name = "Reset",
 		description = "Swap 'Check' with 'Reset' on box traps.",
-		position = 32,
+		position = 37,
 		group = "Miscellaneous"
 	)
 	default boolean swapBoxTrap()
@@ -539,7 +541,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "rockCake",
 		name = "Rock Cake Guzzle",
 		description = "Enables Left Click 'Guzzle' on the Dwarven Rock Cake.",
-		position = 33,
+		position = 38,
 		group = "Miscellaneous"
 	)
 	default boolean rockCake()
@@ -551,7 +553,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapRogueschests",
 		name = "Rogues Chests",
 		description = "Swap Rogues Chests from 'Open' to 'Search for traps'.",
-		position = 34,
+		position = 39,
 		group = "Miscellaneous"
 	)
 	default boolean swapRogueschests()
@@ -563,7 +565,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapClimbUpDown",
 		name = "Climb",
 		description = "Swap 'Climb-Up'/'Climb-Down' depending on Shift or Control key.",
-		position = 35,
+		position = 40,
 		group = "Miscellaneous"
 	)
 	default boolean swapClimbUpDown()
@@ -575,7 +577,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapStun",
 		name = "Stun Hoop Snakes",
 		description = "Swap 'Attack' with 'Stun'.",
-		position = 36,
+		position = 41,
 		group = "Miscellaneous"
 	)
 	default boolean swapStun()
@@ -587,7 +589,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSearch",
 		name = "Search",
 		description = "Swap 'Close', 'Shut' with 'Search' on chests, cupboards, etc.",
-		position = 37,
+		position = 42,
 		group = "Miscellaneous"
 	)
 	default boolean swapSearch()
@@ -599,7 +601,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapHardWoodGrove",
 		name = "Hardwood Grove",
 		description = "Swap 'Quick-Pay(100)' and 'Send-Parcel' at Hardwood Grove.",
-		position = 38,
+		position = 43,
 		group = "Miscellaneous"
 	)
 	default boolean swapHardWoodGrove()
@@ -612,7 +614,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "removeObjects",
 		name = "Remove Objects",
 		description = "Removes interaction with the listed objects.",
-		position = 39,
+		position = 44,
 		group = "Miscellaneous"
 	)
 	default boolean getRemoveObjects()
@@ -624,7 +626,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "removedObjects",
 		name = "Objects",
 		description = "Objects listed here will have all interaction be removed.",
-		position = 40,
+		position = 45,
 		group = "Miscellaneous",
 		hidden = true,
 		unhide = "removeObjects"
@@ -638,7 +640,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapslayer",
 		name = "Swap Slayer Ring",
 		description = "",
-		position = 41,
+		position = 46,
 		group = "Teleportation"
 	)
 	default boolean getSlayerRing()
@@ -650,7 +652,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "slayerringmode",
 		name = "Mode",
 		description = "",
-		position = 42,
+		position = 47,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapslayer"
@@ -666,7 +668,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyOne",
 		name = "Swappable Buy One",
 		description = "",
-		position = 43,
+		position = 48,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyOne()
@@ -679,7 +681,7 @@ public interface MenuEntrySwapperConfig extends Config
 		name = "Items",
 		description = "",
 		group = "Shop / stores",
-		position = 44,
+		position = 49,
 		hidden = true,
 		unhide = "swapBuyOne"
 	)
@@ -692,7 +694,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFive",
 		name = "Swappable Buy Five",
 		description = "",
-		position = 45,
+		position = 50,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFive()
@@ -704,7 +706,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiveItems",
 		name = "Items",
 		description = "",
-		position = 46,
+		position = 51,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFive"
@@ -718,7 +720,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyTen",
 		name = "Swappable Buy Ten",
 		description = "",
-		position = 47,
+		position = 52,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyTen()
@@ -730,7 +732,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyTenItems",
 		name = "Items",
 		description = "",
-		position = 48,
+		position = 53,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyTen"
@@ -744,7 +746,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBuyFifty",
 		name = "Swappable Buy Fifty",
 		description = "",
-		position = 49,
+		position = 54,
 		group = "Shop / stores"
 	)
 	default boolean getSwapBuyFifty()
@@ -756,7 +758,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "buyFiftyItems",
 		name = "Items",
 		description = "",
-		position = 50,
+		position = 55,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapBuyFifty"
@@ -770,7 +772,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellOne",
 		name = "Swappable Sell One",
 		description = "",
-		position = 51,
+		position = 56,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellOne()
@@ -782,7 +784,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellOneItems",
 		name = "Items",
 		description = "",
-		position = 52,
+		position = 57,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellOne"
@@ -796,7 +798,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFive",
 		name = "Swappable Sell Five",
 		description = "",
-		position = 53,
+		position = 58,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFive()
@@ -808,7 +810,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiveItems",
 		name = "Items",
 		description = "",
-		position = 54,
+		position = 59,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFive"
@@ -822,7 +824,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellTen",
 		name = "Swappable Sell Ten",
 		description = "",
-		position = 55,
+		position = 60,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellTen()
@@ -834,7 +836,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellTenItems",
 		name = "Items",
 		description = "",
-		position = 56,
+		position = 61,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellTen"
@@ -848,7 +850,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSellFifty",
 		name = "Swappable Sell Fifty",
 		description = "",
-		position = 57,
+		position = 62,
 		group = "Shop / stores"
 	)
 	default boolean getSwapSellFifty()
@@ -860,7 +862,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "sellFiftyItems",
 		name = "Items",
 		description = "",
-		position = 58,
+		position = 63,
 		group = "Shop / stores",
 		hidden = true,
 		unhide = "swapSellFifty"
@@ -902,7 +904,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstruction",
 		name = "Easy Construction",
 		description = "Makes 'Remove'/'Build' the default option for listed items.",
-		position = 59,
+		position = 64,
 		group = "Skilling"
 	)
 
@@ -915,7 +917,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "getTempConstructionItems",
 		name = "Build Items",
 		description = "",
-		position = 60,
+		position = 65,
 		group = "Skilling",
 		hidden = true,
 		unhide = "getTempConstruction"
@@ -929,7 +931,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSmithing",
 		name = "Swap Smithing",
 		description = "Enables swapping of 'Smith-1' and 'Smith-all' options.",
-		position = 61,
+		position = 66,
 		group = "Skilling"
 	)
 	default boolean getSwapSmithing()
@@ -941,7 +943,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTanning",
 		name = "Swap Tanning",
 		description = "Enables swapping of 'Tan-1' and 'Tan-all' options.",
-		position = 62,
+		position = 67,
 		group = "Skilling"
 	)
 	default boolean getSwapTanning()
@@ -953,7 +955,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmill",
 		name = "Swap Sawmill Operator",
 		description = "Makes 'Buy-plank' the default option on the Sawmill Operator.",
-		position = 63,
+		position = 68,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmill()
@@ -965,7 +967,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSawmillPlanks",
 		name = "Swap Buy Planks",
 		description = "Makes 'Buy All' the default option when buying planks.",
-		position = 64,
+		position = 69,
 		group = "Skilling"
 	)
 	default boolean getSwapSawmillPlanks()
@@ -977,7 +979,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPuroPuro",
 		name = "Swap Puro-Puro Wheat",
 		description = "",
-		position = 65,
+		position = 70,
 		group = "Skilling"
 	)
 	default boolean getSwapPuro()
@@ -991,7 +993,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAssignment",
 		name = "Assignment",
 		description = "Swap 'Talk-to' with 'Assignment' for Slayer Masters. This will take priority over swapping Trade.",
-		position = 66,
+		position = 71,
 		group = "Talk-To"
 	)
 	default boolean swapAssignment()
@@ -1003,7 +1005,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapBankExchange",
 		name = "Bank/Exchange",
 		description = "Swap Talk-to with Bank or Exchange on NPC<br>Example: Banker, Grand Exchange Clerk, Tool Leprechaun, Void Knight",
-		position = 67,
+		position = 72,
 		group = "Talk-To"
 	)
 	default boolean swapBankExchange()
@@ -1015,7 +1017,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapContract",
 		name = "Contract",
 		description = "Swap 'Talk-to' with 'Contract' on Guildmaster Jane.",
-		position = 68,
+		position = 73,
 		group = "Talk-To"
 	)
 	default boolean swapContract()
@@ -1028,7 +1030,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapInteract",
 		name = "Interact",
 		description = "Swap options for generic interactions on NPCs<br>Example: Decant for Bob Barter, Repairs for Dark Mage, Claim Slime for Robin, Claim Dynamite",
-		position = 72,
+		position = 74,
 		group = "Talk-To"
 	)
 	default boolean swapInteract()
@@ -1040,7 +1042,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPickpocket",
 		name = "Pickpocket",
 		description = "Swap Talk-to with Pickpocket on NPC<br>Example: Man, Woman",
-		position = 74,
+		position = 75,
 		group = "Talk-To"
 	)
 	default boolean swapPickpocket()
@@ -1052,7 +1054,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPay",
 		name = "Pay",
 		description = "Swap 'Talk-to' with 'Pay' on various NPCs.<br>Example: Elstan, Heskel, Fayeth.",
-		position = 75,
+		position = 76,
 		group = "Talk-To"
 	)
 	default boolean swapPay()
@@ -1064,7 +1066,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapAbyssTeleport",
 		name = "Teleport to Abyss",
 		description = "Swap 'Talk-to' with 'Teleport' for the Mage of Zamorak.",
-		position = 76,
+		position = 77,
 		group = "Talk-To"
 	)
 	default boolean swapAbyssTeleport()
@@ -1076,7 +1078,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTrade",
 		name = "Trade",
 		description = "Swap 'Talk-to' with 'Trade' on various NPCs.<br>Example: Shop keeper, Shop assistant.",
-		position = 77,
+		position = 78,
 		group = "Talk-To"
 	)
 	default boolean swapTrade()
@@ -1085,11 +1087,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "swapTravel",
-		name = "Travel",
-		description = "Swap 'Talk-to' with 'Travel', 'Take-boat', 'Pay-fare', 'Charter' on various NPCs.<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember.",
-		position = 78,
-		group = "Talk-To"
+			keyName = "swapTravel",
+			name = "Travel",
+			description = "Swap 'Talk-to' with 'Travel', 'Take-boat', 'Pay-fare', 'Charter' on various NPCs.<br>Example: Squire, Monk of Entrana, Customs officer, Trader Crewmember.",
+			position = 79,
+			group = "Talk-To"
 	)
 	default boolean swapTravel()
 	{
@@ -1099,7 +1101,9 @@ public interface MenuEntrySwapperConfig extends Config
 	@ConfigItem(
 			keyName = "swapMinigame",
 			name = "Minigames",
-			description = "Swap Talk-to with Start-Minigame, Story, Dream on NPC<br>Example: Guardian mummy, Juna, Dominic Onion"
+			description = "Swap Talk-to with Start-Minigame, Story, Dream on NPC<br>Example: Guardian mummy, Juna, Dominic Onion",
+			position = 80,
+			group = "Talk-To"
 	)
 	default boolean swapMinigame()
 	{
@@ -1136,7 +1140,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapFairyRing",
 		name = "Fairy Ring",
 		description = "Swap 'Zanaris' with 'Last-destination' or 'Configure' on Fairy rings.",
-		position = 84,
+		position = 83,
 		group = "Teleportation"
 	)
 	default boolean swapFairyRing()
@@ -1148,7 +1152,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "fairyring",
 		name = "Mode",
 		description = "",
-		position = 85,
+		position = 84,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapFairyRing"
@@ -1162,7 +1166,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapObelisk",
 		name = "Obelisk",
 		description = "Swap the options on wilderness obelisks between 'Activate', 'Set destination' or 'Teleport to destination'.",
-		position = 86,
+		position = 85,
 		group = "Teleportation"
 	)
 	default boolean swapObelisk()
@@ -1174,7 +1178,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "obelisk",
 		name = "Mode",
 		description = "",
-		position = 87,
+		position = 86,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapObelisk"
@@ -1188,7 +1192,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapTeleportItem",
 		name = "Teleport Items",
 		description = "Swap 'Wear' or 'Wield' with 'Rub' or 'Teleport' on teleport items.<br>Example: Amulet of glory, Explorer's ring, Chronicle.",
-		position = 88,
+		position = 87,
 		group = "Teleportation"
 	)
 	default boolean swapTeleportItem()
@@ -1200,7 +1204,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapWildernessLever",
 		name = "Wilderness Lever",
 		description = "Swap the wilderness lever left click to be Edgeville/Ardougne.",
-		position = 89,
+		position = 88,
 		group = "Teleportation"
 	)
 	default boolean swapWildernessLever()
@@ -1212,7 +1216,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapNexus",
 		name = "Portal Nexus",
 		description = "Makes the teleport menu have priority over the left click destination on the portal nexus.",
-		position = 90,
+		position = 99,
 		group = "Teleportation"
 	)
 	default boolean swapNexus()
@@ -1224,7 +1228,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGamesNecklace",
 		name = "Swap Games Necklace",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Games Necklace.",
-		position = 91,
+		position = 100,
 		group = "Teleportation"
 	)
 	default boolean getGamesNecklace()
@@ -1236,7 +1240,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gamesNecklaceMode",
 		name = "Mode",
 		description = "",
-		position = 92,
+		position = 101,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGamesNecklace"
@@ -1250,7 +1254,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDuelingRing",
 		name = "Swap Dueling Ring",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Dueling.",
-		position = 93,
+		position = 102,
 		group = "Teleportation"
 	)
 	default boolean getDuelingRing()
@@ -1262,7 +1266,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "duelingRingMode",
 		name = "Mode",
 		description = "",
-		position = 94,
+		position = 103,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDuelingRing"
@@ -1276,7 +1280,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapGlory",
 		name = "Swap Glory",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Amulet of Glory / Amulet of Eternal Glory.",
-		position = 95,
+		position = 104,
 		group = "Teleportation"
 	)
 	default boolean getGlory()
@@ -1288,7 +1292,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "gloryMode",
 		name = "Mode",
 		description = "",
-		position = 96,
+		position = 105,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapGlory"
@@ -1302,7 +1306,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapSkill",
 		name = "Swap Skill",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Skills Necklace.",
-		position = 97,
+		position = 106,
 		group = "Teleportation"
 	)
 	default boolean getSkillsNecklace()
@@ -1314,7 +1318,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "skillsnecklacemode",
 		name = "Mode",
 		description = "",
-		position = 98,
+		position = 107,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapSkill"
@@ -1328,7 +1332,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapPassage",
 		name = "Swap Passage",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Necklace of Passage.",
-		position = 99,
+		position = 108,
 		group = "Teleportation"
 	)
 	default boolean getNecklaceofPassage()
@@ -1340,7 +1344,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "necklaceofpassagemode",
 		name = "Mode",
 		description = "",
-		position = 100,
+		position = 109,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapPassage"
@@ -1354,7 +1358,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapDigsite",
 		name = "Swap Digsite",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Digsite Pendant.",
-		position = 101,
+		position = 110,
 		group = "Teleportation"
 	)
 	default boolean getDigsitePendant()
@@ -1366,7 +1370,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "digsitependantmode",
 		name = "Mode",
 		description = "",
-		position = 102,
+		position = 111,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapDigsite"
@@ -1380,7 +1384,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapCombat",
 		name = "Swap Combat",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Combat Bracelet.",
-		position = 103,
+		position = 112,
 		group = "Teleportation"
 	)
 	default boolean getCombatBracelet()
@@ -1392,7 +1396,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "combatbraceletmode",
 		name = "Mode",
 		description = "",
-		position = 104,
+		position = 113,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapCombat"
@@ -1406,7 +1410,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapburning",
 		name = "Swap Burning",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Burning Amulet.",
-		position = 105,
+		position = 114,
 		group = "Teleportation"
 	)
 	default boolean getBurningAmulet()
@@ -1418,7 +1422,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "burningamuletmode",
 		name = "Mode",
 		description = "",
-		position = 106,
+		position = 115,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapburning"
@@ -1432,7 +1436,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapxeric",
 		name = "Swap Xeric's",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Xeric's Talisman.",
-		position = 107,
+		position = 116,
 		group = "Teleportation"
 	)
 	default boolean getXericsTalisman()
@@ -1444,7 +1448,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "xericstalismanmode",
 		name = "Mode",
 		description = "",
-		position = 108,
+		position = 117,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapxeric"
@@ -1458,7 +1462,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "swapwealth",
 		name = "Swap Wealth",
 		description = "Swap the left click 'remove' option with the desired teleport location on a worn Ring of Wealth.",
-		position = 109,
+		position = 118,
 		group = "Teleportation"
 	)
 	default boolean getRingofWealth()
@@ -1470,7 +1474,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "ringofwealthmode",
 		name = "Mode",
 		description = "",
-		position = 110,
+		position = 119,
 		group = "Teleportation",
 		hidden = true,
 		unhide = "swapwealth"
@@ -1486,7 +1490,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideExamine",
 		name = "Hide Examine",
 		description = "Hides the 'Examine' option from the right click menu.",
-		position = 111,
+		position = 120,
 		group = "Right Click Options"
 	)
 	default boolean hideExamine()
@@ -1498,7 +1502,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideTradeWith",
 		name = "Hide Trade With",
 		description = "Hides the 'Trade with' option from the right click menu.",
-		position = 112,
+		position = 121,
 		group = "Right Click Options"
 	)
 	default boolean hideTradeWith()
@@ -1510,7 +1514,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideReport",
 		name = "Hide Report",
 		description = "Hides the 'Report' option from the right click menu.",
-		position = 113,
+		position = 122,
 		group = "Right Click Options"
 	)
 	default boolean hideReport()
@@ -1522,7 +1526,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideLookup",
 		name = "Hide Lookup",
 		description = "Hides the 'Lookup' option from the right click menu.",
-		position = 114,
+		position = 123,
 		group = "Right Click Options"
 	)
 	default boolean hideLookup()
@@ -1534,7 +1538,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideNet",
 		name = "Hide Net",
 		description = "Hides the 'Net' option from the right click menu.",
-		position = 115,
+		position = 124,
 		group = "Right Click Options"
 	)
 	default boolean hideNet()
@@ -1546,7 +1550,7 @@ public interface MenuEntrySwapperConfig extends Config
 		keyName = "hideBait",
 		name = "Hide Bait",
 		description = "Hides the 'Bait' option from the right click menu.",
-		position = 116,
+		position = 125,
 		group = "Right Click Options"
 	)
 	default boolean hideBait()
@@ -1557,11 +1561,11 @@ public interface MenuEntrySwapperConfig extends Config
 	//----------------------Untradeables---------------------------//
 
 	@ConfigItem(
-			keyName = "hideDestroyRunepouch",
-			name = "Hide Destroy on Rune Pouch",
-			description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
-			position = 117,
-			group = "Untradeables"
+		keyName = "hideDestroyRunepouch",
+		name = "Hide Destroy on Rune Pouch",
+		description = "Hides the 'Destroy' option when right clicking a Rune pouch.",
+		position = 126,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyRunepouch()
 	{
@@ -1569,11 +1573,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyCoalbag",
-			name = "Hide Destroy on Coal bag",
-			description = "Hides the 'Destroy' option when right clicking a Coal bag.",
-			position = 118,
-			group = "Untradeables"
+		keyName = "hideDestroyCoalbag",
+		name = "Hide Destroy on Coal bag",
+		description = "Hides the 'Destroy' option when right clicking a Coal bag.",
+		position = 127,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyCoalbag()
 	{
@@ -1581,11 +1585,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyHerbsack",
-			name = "Hide Destroy on Herb sack",
-			description = "Hides the 'Destroy' option when right clicking a Herb sack.",
-			position = 119,
-			group = "Untradeables"
+		keyName = "hideDestroyHerbsack",
+		name = "Hide Destroy on Herb sack",
+		description = "Hides the 'Destroy' option when right clicking a Herb sack.",
+		position = 128,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyHerbsack()
 	{
@@ -1593,11 +1597,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyBoltpouch",
-			name = "Hide Destroy on Bolt pouch",
-			description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
-			position = 120,
-			group = "Untradeables"
+		keyName = "hideDestroyBoltpouch",
+		name = "Hide Destroy on Bolt pouch",
+		description = "Hides the 'Destroy' option when right clicking a Bolt pouch.",
+		position = 129,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyBoltpouch()
 	{
@@ -1605,11 +1609,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDestroyGembag",
-			name = "Hide Destroy on Gem bag",
-			description = "Hides the 'Destroy' option when right clicking a Gem bag.",
-			position = 121,
-			group = "Untradeables"
+		keyName = "hideDestroyGembag",
+		name = "Hide Destroy on Gem bag",
+		description = "Hides the 'Destroy' option when right clicking a Gem bag.",
+		position = 130,
+		group = "Untradeables"
 	)
 	default boolean hideDestroyGembag()
 	{
@@ -1617,11 +1621,11 @@ public interface MenuEntrySwapperConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "hideDropRunecraftingPouch",
-			name = "Hide Drop on RC pouches",
-			description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
-			position = 122,
-			group = "Untradeables"
+		keyName = "hideDropRunecraftingPouch",
+		name = "Hide Drop on RC pouches",
+		description = "Hides the 'Drop' option when right clicking a Small, Medium, Large, or Giant pouch.",
+		position = 131,
+		group = "Untradeables"
 	)
 	default boolean hideDropRunecraftingPouch()
 	{
@@ -1631,11 +1635,11 @@ public interface MenuEntrySwapperConfig extends Config
 	//------------------------------------------------------------//
 
 	@ConfigItem(
-			keyName = "swapImps",
-			name = "Impling Jars",
-			description = "Don't open implings if bank has a clue.",
-			position = 123,
-			group = "Miscellaneous"
+		keyName = "swapImps",
+		name = "Impling Jars",
+		description = "Don't open implings if bank has a clue.",
+		position = 132,
+		group = "Miscellaneous"
 	)
 	default boolean swapImps()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -904,7 +904,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			if (config.swapPickpocket())
 			{
-				swap(client,"pickpocket", option, target, true);
+				swap(client, "pickpocket", option, target, true);
 			}
 
 			if (config.swapHardWoodGrove() && target.contains("rionasta"))
@@ -1130,7 +1130,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		}
 		else if (config.swapQuick() && option.equals("leave tomb"))
 		{
-			swap(client,"quick-leave", option, target, true);
+			swap(client, "quick-leave", option, target, true);
 		}
 		else if (config.swapAdmire() && option.equals("admire"))
 		{
@@ -1183,7 +1183,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		}
 		else if (config.swapCoalBag() && option.contains("deposit") && target.equals("coal bag"))
 		{
-			swap(client,"empty", option, target, true);
+			swap(client, "empty", option, target, true);
 		}
 		else if (config.swapBones() && option.equals("bury"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -979,7 +979,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 				if (!(target.equals("trader crewmember") || target.equals("trader stan")) || config.charterOption().equals(CharterOption.CHARTER))
 				{
-					swap(client,"charter", option, target, true);
+					swap(client, "charter", option, target, true);
 				}
 			}
 
@@ -992,6 +992,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 			if (config.swapQuick())
 			{
 				swap(client, "quick-travel", option, target, true);
+			}
+
+			if (config.swapEnchant())
+			{
+				swap(client, "enchant", option, target, true);
 			}
 
 		}
@@ -1133,6 +1138,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		else if (config.swapQuick() && option.equals("open"))
 		{
 			swap(client, "quick-open", option, target, true);
+		}
+		else if (config.swapQuick() && option.equals("enter"))
+		{
+			swap(client, "quick-enter", option, target, true);
 		}
 		else if (config.swapQuick() && option.equals("leave tomb"))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -81,6 +81,7 @@ import net.runelite.client.plugins.menuentryswapper.util.FairyRingMode;
 import net.runelite.client.plugins.menuentryswapper.util.HouseMode;
 import net.runelite.client.plugins.menuentryswapper.util.ObeliskMode;
 import net.runelite.client.plugins.menuentryswapper.util.OccultAltarMode;
+import net.runelite.client.plugins.menuentryswapper.util.CharterOption;
 import static net.runelite.client.util.MenuUtil.swap;
 import net.runelite.client.util.MiscUtils;
 import net.runelite.client.util.Text;
@@ -943,7 +944,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "buy-plank", option, target, true);
 			}
 
-			if (config.swapTrade())
+			if (config.swapTrade() && (!(target.equals("trader crewmember") || target.equals("trader stan")) || config.charterOption().equals(CharterOption.TRADE)))
 			{
 				swap(client, "trade", option, target, true);
 				swap(client, "trade-with", option, target, true);
@@ -974,6 +975,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))
 				{
 					swap(client, "teleport", option, target, true);
+				}
+
+				if (!(target.equals("trader crewmember") || target.equals("trader stan")) || config.charterOption().equals(CharterOption.CHARTER))
+				{
+					swap(client,"charter", option, target, true);
 				}
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -902,23 +902,19 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (option.equals("talk-to"))
 		{
-			if (config.swapPickpocket() && target.contains("h.a.m."))
+			if (config.swapPickpocket())
 			{
-				swap(client, "pickpocket", option, target, true);
-			}
-
-			if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))
-			{
-				swap(client, "teleport", option, target, true);
+				swap(client,"pickpocket", option, target, true);
 			}
 
 			if (config.swapHardWoodGrove() && target.contains("rionasta"))
 			{
 				swap(client, "send-parcel", option, target, true);
 			}
-			if (config.swapBank())
+			if (config.swapBankExchange())
 			{
 				swap(client, "bank", option, target, true);
+				swap(client, "exchange", option, target, true);
 			}
 
 			if (config.swapContract())
@@ -926,14 +922,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "contract", option, target, true);
 			}
 
-			if (config.swapExchange())
-			{
-				swap(client, "exchange", option, target, true);
-			}
-
-			if (config.swapDarkMage())
+			if (config.swapInteract())
 			{
 				swap(client, "repairs", option, target, true);
+				swap(client, "claim-slime", option, target, true);
+				swap(client, "decant", option, target, true);
+				swap(client, "claim", option, target, true);
+				swap(client, "heal", option, target, true);
+				swap(client, "help", option, target, true);
 			}
 
 			// make sure assignment swap is higher priority than trade swap for slayer masters
@@ -947,11 +943,6 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "buy-plank", option, target, true);
 			}
 
-			if (config.claimDynamite() && target.equals("thirus"))
-			{
-				swap(client, "claim", option, target, true);
-			}
-
 			if (config.swapTrade())
 			{
 				swap(client, "trade", option, target, true);
@@ -959,9 +950,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "shop", option, target, true);
 			}
 
-			if (config.claimSlime() && target.equals("robin"))
+			if (config.swapMinigame())
 			{
-				swap(client, "claim-slime", option, target, true);
+				swap(client, "story", option, target, true);
+				swap(client, "escort", option, target, true);
+				swap(client, "dream", option, target, true);
+				swap(client, "start-minigame", option, target, true);
 			}
 
 			if (config.swapTravel())
@@ -976,6 +970,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "rellekka", option, target, true);
 				swap(client, "follow", option, target, true);
 				swap(client, "transport", option, target, true);
+
+				if (config.swapAbyssTeleport() && target.contains("mage of zamorak"))
+				{
+					swap(client, "teleport", option, target, true);
+				}
 			}
 
 			if (config.swapPay())
@@ -984,30 +983,11 @@ public class MenuEntrySwapperPlugin extends Plugin
 				swap(client, "pay (", option, target, false);
 			}
 
-			if (config.swapDream())
-			{
-				swap(client, "dream", option, target, true);
-			}
-
-			if (config.swapDecant())
-			{
-				swap(client, "decant", option, target, true);
-			}
-
 			if (config.swapQuick())
 			{
 				swap(client, "quick-travel", option, target, true);
 			}
 
-			if (config.swapStory())
-			{
-				swap(client, "story", option, target, true);
-			}
-
-			if (config.swapEscort())
-			{
-				swap(client, "escort", option, target, true);
-			}
 		}
 
 		else if (config.swapWildernessLever() && target.equals("lever") && option.equals("ardougne"))
@@ -1025,18 +1005,9 @@ public class MenuEntrySwapperPlugin extends Plugin
 			swap(client, "stun", option, target, true);
 		}
 
-		else if (config.swapTravel() && option.equals("pass") && target.equals("energy barrier"))
+		else if (config.swapTravel() && (option.equals("pass") || option.equals("open")))
 		{
-			swap(client, "pay-toll(2-ecto)", option, target, true);
-		}
-
-		else if (config.swapTravel() && option.equals("open") && target.equals("gate"))
-		{
-			swap(client, "pay-toll(10gp)", option, target, true);
-		}
-		else if (config.swapHardWoodGrove() && option.equals("open") && target.equals("hardwood grove doors"))
-		{
-			swap(client, "quick-pay(100)", option, target, true);
+			swap(client, "pay-toll", option, target, false);
 		}
 		else if (config.swapTravel() && option.equals("inspect") && target.equals("trapdoor"))
 		{
@@ -1157,7 +1128,10 @@ public class MenuEntrySwapperPlugin extends Plugin
 		{
 			swap(client, "quick-open", option, target, true);
 		}
-
+		else if (config.swapQuick() && option.equals("leave tomb"))
+		{
+			swap(client,"quick-leave", option, target, true);
+		}
 		else if (config.swapAdmire() && option.equals("admire"))
 		{
 			swap(client, "teleport", option, target, true);
@@ -1202,17 +1176,14 @@ public class MenuEntrySwapperPlugin extends Plugin
 		}
 
 		// Put all item-related swapping after shift-click
-		else if (config.swapTeleportItem() && option.equals("wear"))
+		else if (config.swapTeleportItem() && (option.equals("wear") || option.equals("wield")))
 		{
 			swap(client, "rub", option, target, true);
 			swap(client, "teleport", option, target, true);
 		}
-		else if (option.equals("wield"))
+		else if (config.swapCoalBag() && option.contains("deposit") && target.equals("coal bag"))
 		{
-			if (config.swapTeleportItem())
-			{
-				swap(client, "teleport", option, target, true);
-			}
+			swap(client,"empty", option, target, true);
 		}
 		else if (config.swapBones() && option.equals("bury"))
 		{
@@ -1370,6 +1341,12 @@ public class MenuEntrySwapperPlugin extends Plugin
 		if (config.getBurningAmulet())
 		{
 			menuManager.addSwap("remove", "burning amulet", config.getBurningAmuletMode().toString());
+		}
+
+		if (config.teleEquippedCape())
+		{
+			menuManager.addSwap("remove", "tele to poh", config.telecapeMode().toString());
+			menuManager.addSwap("remove", "teleport", config.telecapeMode().toString());
 		}
 
 		if (config.getCombatBracelet())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/CharterOption.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/CharterOption.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.menuentryswapper.util;
+
+public enum CharterOption
+{
+	TRADE("Trade"),
+	CHARTER("Charter");
+
+	private final String name;
+
+	CharterOption(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/teleEquippedMode.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/util/teleEquippedMode.java
@@ -1,0 +1,20 @@
+package net.runelite.client.plugins.menuentryswapper.util;
+
+public enum teleEquippedMode
+{
+	TELE_TO_POH("Tele to POH"),
+	TELEPORT("teleport");
+
+	private final String name;
+
+	teleEquippedMode(String name)
+	{
+		this.name = name;
+	}
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Supersedes/Closes runelite#7353
Supersedes/Closes runelite#7415
Supersedes/Closes runelite#7493
Supersedes/Closes runelite#7401
Supersedes/Closes runelite#5383

Streamline teleport item swaps

**Pickpock swap no longer limited by just HAM members**

Move Mage of Zamorak teleport to Travel swap
It is a travel swap so there's no reason for it to have it's own option.

Unify bank and exchange options
There's no reason for these to be separate options.

Unify interact options
Grouped generic interactions swaps for NPCs

Unify minigames options
Grouped minigames swaps

Swap Coal Bag Empty 
Makes Empty the left click option when in a bank

Teleport Equipped Cape
Makes Teleport/Tele to POH the left click option on equip screen

'Trade' or 'Charter' as first option



