### PR TITLE
Rework MenuManager to only swap the top entry, once per client tick

### DIFF
--- a/injector-plugin/src/main/java/net/runelite/injector/raw/ClearColorBuffer.java
+++ b/injector-plugin/src/main/java/net/runelite/injector/raw/ClearColorBuffer.java
@@ -70,50 +70,52 @@ public class ClearColorBuffer
 						continue;
 					}
 
-					if (((InvokeStatic) i).getMethod().equals(fillRectangle))
+					if (!((InvokeStatic) i).getMethod().equals(fillRectangle))
 					{
-						int indexToReturnTo = it.nextIndex();
-						count++;
-						it.previous();
-						Instruction current = it.previous();
-						if (current instanceof LDC && ((LDC) current).getConstantAsInt() == 0)
+						continue;
+					}
+
+					int indexToReturnTo = it.nextIndex();
+					count++;
+					it.previous();
+					Instruction current = it.previous();
+					if (current instanceof LDC && ((LDC) current).getConstantAsInt() == 0)
+					{
+						int varIdx = 0;
+						for (; ; )
 						{
-							int varIdx = 0;
-							for (; ; )
+							current = it.previous();
+							if (current instanceof ILoad && ((ILoad) current).getVariableIndex() == 3 - varIdx)
 							{
-								current = it.previous();
-								if (current instanceof ILoad && ((ILoad) current).getVariableIndex() == 3 - varIdx)
-								{
-									varIdx++;
-									log.debug(varIdx + " we can count yay");
-									continue;
-								}
-
-								break;
+								varIdx++;
+								log.debug(varIdx + " we can count yay");
+								continue;
 							}
 
-							if (varIdx == 4)
-							{
-								for (; !(current instanceof InvokeStatic); )
-								{
-									current = it.next();
-								}
-								assert it.nextIndex() == indexToReturnTo;
-
-								it.set(new InvokeStatic(ins, clearBuffer));
-								replaced++;
-								log.debug("Found drawRectangle at {}. Found: {}, replaced {}", m.getName(), count, replaced);
-							}
-							else
-							{
-								log.debug("Welp, guess this wasn't it chief " + m);
-							}
+							break;
 						}
 
-						while (it.nextIndex() != indexToReturnTo)
+						if (varIdx == 4)
 						{
-							it.next();
+							for (; !(current instanceof InvokeStatic); )
+							{
+								current = it.next();
+							}
+							assert it.nextIndex() == indexToReturnTo;
+
+							it.set(new InvokeStatic(ins, clearBuffer));
+							replaced++;
+							log.debug("Found drawRectangle at {}. Found: {}, replaced {}", m.getName(), count, replaced);
 						}
+						else
+						{
+							log.debug("Welp, guess this wasn't it chief " + m);
+						}
+					}
+
+					while (it.nextIndex() != indexToReturnTo)
+					{
+						it.next();
 					}
 				}
 			}

--- a/injector-plugin/src/main/java/net/runelite/injector/raw/Occluder.java
+++ b/injector-plugin/src/main/java/net/runelite/injector/raw/Occluder.java
@@ -78,6 +78,6 @@ public class Occluder
 		}
 
 		log.info("Changed {} values in occlude()", replaced);
-		log.info("occluder took {}", stopwatch.toString());
+		log.info("Occluder took {}", stopwatch.toString());
 	}
 }

--- a/injector-plugin/src/main/java/net/runelite/injector/raw/RasterizerHook.java
+++ b/injector-plugin/src/main/java/net/runelite/injector/raw/RasterizerHook.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 
 public class RasterizerHook
 {
+	// TODO: Should probably make this better
 	private static final Logger logger = LoggerFactory.getLogger(ClearColorBuffer.class);
 	private static final int val = -16777216;
 
@@ -318,7 +319,7 @@ public class RasterizerHook
 			{
 				if ((int) ic.getPops().get(0).getValue().getValue() == 0)
 				{
-					logger.info("Didn't add hook in method {}.{}. {} added, {} total, value 0", method.getClassFile().getClassName(), method.getName(), count - startCount, count);
+					logger.debug("Didn't add hook in method {}.{}. {} added, {} total, value 0", method.getClassFile().getClassName(), method.getName(), count - startCount, count);
 					return;
 				}
 			}
@@ -326,7 +327,7 @@ public class RasterizerHook
 			ins.getInstructions().add(index, new IOr(ins, InstructionType.IOR)); // Add instructions backwards
 			ins.getInstructions().add(index, new LDC(ins, val));
 			count++;
-			logger.info("Added hook in method {}.{}. {} added, {} total", method.getClassFile().getClassName(), method.getName(), count - startCount, count);
+			logger.debug("Added hook in method {}.{}. {} added, {} total", method.getClassFile().getClassName(), method.getName(), count - startCount, count);
 		});
 
 		ex.run();

--- a/injector-plugin/src/main/java/net/runelite/injector/raw/RenderDraw.java
+++ b/injector-plugin/src/main/java/net/runelite/injector/raw/RenderDraw.java
@@ -1,5 +1,6 @@
 package net.runelite.injector.raw;
 
+import com.google.common.base.Stopwatch;
 import java.util.ArrayList;
 import java.util.List;
 import net.runelite.asm.attributes.code.Instruction;
@@ -32,18 +33,18 @@ public class RenderDraw
 
 	public void inject() throws InjectionException
 	{
-		injectColorBufferHooks();
-	}
+		Stopwatch stopwatch = Stopwatch.createStarted();
 
-	private void injectColorBufferHooks() throws InjectionException
-	{
 		net.runelite.asm.Method obmethod = findMethod(inject, "drawTile");
 		Method renderDraw = findMethod(inject, "renderDraw").getPoolMethod();
+
 		Instructions ins = obmethod.getCode().getInstructions();
 		replace(ins, renderDraw);
+
+		log.info("RenderDraw took {}", stopwatch.toString());
 	}
 
-	private void replace(Instructions ins, net.runelite.asm.pool.Method meth)
+	private void replace(Instructions ins, net.runelite.asm.pool.Method meth) throws InjectionException
 	{
 		List<Instruction> insList = new ArrayList<>();
 		int count = 0;
@@ -55,12 +56,26 @@ public class RenderDraw
 				{
 					int index = ins.getInstructions().indexOf(i);
 					count++;
-					log.info("Found renderDraw at index {}, {} found.", index, count);
+					log.debug("Found renderDraw at index {}, {} found.", index, count);
 
 					insList.add(i);
 				}
 			}
 		}
+
+		if (count < 21)
+		{
+			throw new InjectionException("Not all renderDraws were found");
+		}
+		else if (count != 21)
+		{
+			log.warn("Found {} renderDraws while 21 were expected. Rev update?", count);
+		}
+		else
+		{
+			log.info("RenderDraw replaced {} method calls", count);
+		}
+
 
 		for (Instruction i : insList)
 		{

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1667,4 +1667,10 @@ public interface Client extends GameShell
 	String getSelectedSpellName();
 	
 	boolean getIsSpellSelected();
+
+	/**
+	 * Sorts the current menu entries in the same way the client does this.
+	 * The last entry will be the left click one after this.
+	 */
+	void sortMenuEntries();
 }

--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
@@ -26,6 +26,7 @@ package net.runelite.api.events;
 
 import lombok.Data;
 import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
 
 /**
  * An event where a menu option has been clicked.
@@ -42,31 +43,71 @@ import net.runelite.api.MenuAction;
 public class MenuOptionClicked
 {
 	/**
-	 * The action parameter used in the click.
+	 * The actual MenuEntry object representing what was clicked
 	 */
-	private int actionParam;
+	private final MenuEntry menuEntry;
+
 	/**
 	 * The option text added to the menu.
 	 */
-	private String menuOption;
+	public String getOption()
+	{
+		return menuEntry.getOption();
+	}
+
 	/**
 	 * The target of the action.
 	 */
-	private String menuTarget;
+	public String getTarget()
+	{
+		return menuEntry.getTarget();
+	}
+
 	/**
-	 * The action performed.
+	 * MenuAction but int-ish
 	 */
-	private MenuAction menuAction;
+	public int getType()
+	{
+		return menuEntry.getType();
+	}
+
 	/**
 	 * The ID of the object, actor, or item that the interaction targets.
 	 */
-	private int id;
+	public int getIdentifier()
+	{
+		return menuEntry.getIdentifier();
+	}
+
 	/**
-	 * The ID of the widget where the menu was clicked.
-	 *
-	 * @see net.runelite.api.WidgetID
+	 * The action parameter used in the click.
 	 */
-	private int widgetId;
+	public int getActionParam0()
+	{
+		return menuEntry.getParam0();
+	}
+
+	/**
+	 * shit docs
+	 */
+	public int getActionParam1()
+	{
+		return menuEntry.getParam1();
+	}
+
+	public boolean isForceLeftClick()
+	{
+		return menuEntry.isForceLeftClick();
+	}
+
+	/**
+	 * The action performed.
+	 */
+	public MenuAction getMenuAction()
+	{
+		return MenuAction.of(getType());
+	}
+
 	/**
 	 * Whether or not the event has been consumed by a subscriber.
 	 */

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -42,9 +42,11 @@ import javax.inject.Singleton;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.MenuAction;
-import static net.runelite.api.MenuAction.MENU_ACTION_DEPRIORITIZE_OFFSET;
+import static net.runelite.api.MenuAction.GAME_OBJECT_FIRST_OPTION;
+import static net.runelite.api.MenuAction.WIDGET_DEFAULT;
 import net.runelite.api.MenuEntry;
 import net.runelite.api.NPCDefinition;
+import net.runelite.api.events.ClientTick;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.events.NpcActionChanged;
@@ -147,14 +149,6 @@ public class MenuManager
 		Collection<WidgetMenuOption> options = managedMenuOptions.get(widgetId);
 		MenuEntry[] menuEntries = client.getMenuEntries();
 
-		if (menuEntries.length == 1)
-		{
-			// Menu entries reset, so priority entries should reset as well
-			currentPriorityEntries.clear();
-
-			originalTypes.clear();
-		}
-
 		for (WidgetMenuOption currentMenu : options)
 		{
 			if (!menuContainsCustomMenu(currentMenu))//Don't add if we have already added it to this widget
@@ -210,90 +204,6 @@ public class MenuManager
 					}
 				}
 			}
-
-			copy.add(CANCEL());
-		}
-
-		// Find the current entry in the swaps map
-		ComparableEntry swapEntry = null;
-		for (ComparableEntry e : swaps.keySet())
-		{
-			if (e.matches(newestEntry))
-			{
-				swapEntry = e;
-				break;
-			}
-		}
-
-		if (swapEntry != null)
-		{
-			ComparableEntry swapTarget = swaps.get(swapEntry);
-
-			// Find the target for the swap in current menu entries
-			MenuEntry foundSwap = null;
-			for (MenuEntry entry : Lists.reverse(copy))
-			{
-				if (swapTarget.matches(entry))
-				{
-					foundSwap = entry;
-					break;
-				}
-			}
-
-			if (foundSwap != null)
-			{
-				// This is the type for the entry we're swapping the newest with
-				final int foundType = foundSwap.getType();
-				// This is the type for the newest entry
-				final int lastType = newestEntry.getType();
-
-				// MenuActions with an id of over 1000 get shifted to the back of the menu entry array
-				// They have different id's in the packet buffer though, so we got to modify them back on click
-				// I couldn't get this to work with objects, so we're using modified objectcomposition for that
-				final boolean shouldModifyFoundType = foundType >= 1000;
-
-				final boolean shouldModifyLastType = lastType >= 1000;
-
-				// Bitwise or so we don't end up making things left click when they shouldn't
-				if (shouldModifyFoundType ^ shouldModifyLastType)
-				{
-					int typeToSet;
-					switch (MenuAction.of(shouldModifyFoundType ? foundType : lastType))
-					{
-						case EXAMINE_ITEM_BANK_EQ:
-							typeToSet = MenuAction.WIDGET_DEFAULT.getId();
-							break;
-						case GAME_OBJECT_FIFTH_OPTION:
-							typeToSet = MenuAction.GAME_OBJECT_FIRST_OPTION.getId();
-							break;
-						default:
-							typeToSet = shouldModifyFoundType ? foundType : lastType;
-							break;
-					}
-
-					if (shouldModifyFoundType)
-					{
-						foundSwap.setType(typeToSet);
-						originalTypes.put(foundSwap, foundType);
-					}
-					else
-					{
-						newestEntry.setType(typeToSet);
-						originalTypes.put(newestEntry, lastType);
-
-						// We're probably trying to make something left click, so just slap on
-						// the menu action deprioritize 2000-inator++
-						foundSwap.setType(foundType + MENU_ACTION_DEPRIORITIZE_OFFSET);
-					}
-				}
-
-				// Swap
-				int index = copy.indexOf(foundSwap);
-				int newIndex = copy.indexOf(newestEntry);
-
-				copy.set(index, newestEntry);
-				copy.set(newIndex, foundSwap);
-			}
 		}
 
 		boolean isHidden = false;
@@ -312,6 +222,69 @@ public class MenuManager
 		}
 
 		client.setMenuEntries(copy.toArray(new MenuEntry[0]));
+	}
+
+	@Subscribe
+	private void onClientTick(ClientTick event)
+	{
+		originalTypes.clear();
+		client.sortMenuEntries();
+
+		final MenuEntry[] oldentries = client.getMenuEntries();
+		MenuEntry[] newEntries;
+
+		if (!currentPriorityEntries.isEmpty())
+		{
+			newEntries = new MenuEntry[client.getMenuOptionCount() + 1];
+			newEntries[0] = CANCEL();
+
+			System.arraycopy(oldentries, 0, newEntries, 1, oldentries.length);
+		}
+		else
+		{
+			newEntries = Arrays.copyOf(oldentries, client.getMenuOptionCount());
+		}
+
+		MenuEntry leftClickEntry = newEntries[newEntries.length - 1];
+
+
+		for (ComparableEntry src : swaps.keySet())
+		{
+			if (!src.matches(leftClickEntry))
+			{
+				continue;
+			}
+
+			ComparableEntry tgt = swaps.get(src);
+
+			for (int i = newEntries.length - 2; i > 0; i--)
+			{
+				MenuEntry e = newEntries[i];
+
+				if (tgt.matches(e))
+				{
+					newEntries[newEntries.length - 1] = e;
+					newEntries[i] = leftClickEntry;
+
+					int type = e.getType();
+
+					if (type >= 1000)
+					{
+						int newType = getLeftClickType(type);
+						if (newType != -1 && newType != type)
+						{
+							e.setType(newType);
+							originalTypes.put(e, type);
+						}
+					}
+
+					break;
+				}
+			}
+		}
+
+		client.setMenuEntries(newEntries);
+		currentPriorityEntries.clear();
 	}
 
 	public void addPlayerMenuItem(String menuText)
@@ -375,6 +348,24 @@ public class MenuManager
 		}
 	}
 
+	private int getLeftClickType(int oldType)
+	{
+		if (oldType > 2000)
+		{
+			oldType -= 2000;
+		}
+
+		switch (MenuAction.of(oldType))
+		{
+			case GAME_OBJECT_FIFTH_OPTION:
+				return GAME_OBJECT_FIRST_OPTION.getId();
+			case EXAMINE_ITEM_BANK_EQ:
+				return WIDGET_DEFAULT.getId();
+			default:
+				return oldType;
+		}
+	}
+
 	private void addNpcOption(NPCDefinition composition, String npcOption)
 	{
 		String[] actions = composition.getActions();
@@ -418,69 +409,21 @@ public class MenuManager
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		// if (originalTypes.get(event.ge
-		// ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-		// This right here. That's the moment I realized once again that
-		// this event still is one of the worst fucking things that has
-		// ever happened to this project. MenuOptionClicked right? What
-		// do you expect the data in the event object to be?
-		// A FUCKING MENU ENTRY. Honestly I originally forgot why I wrote
-		// the rant below this, but the hate is coming back to me once again.
-		// What the fuck do you expect me to do? Make another MenuEntry from
-		// all the info WHICH WOULD HAVE BEEN INSIDE THE FUCKING MENUENTRY TO
-		// BEGIN WITH??? I am legit still perplexed over why someone would do
-		// it like this, and I don't want them to take this lightly cause they
-		// should really really really feel terrible about this.
-
-		if (!event.getMenuTarget().equals("do not edit") &&
-			!originalTypes.isEmpty() &&
-			event.getMenuAction() == MenuAction.WIDGET_DEFAULT ||
-			event.getMenuAction() == MenuAction.GAME_OBJECT_FIRST_OPTION)
+		if (originalTypes.containsKey(event.getMenuEntry()) &&
+			!event.getTarget().equals("do not edit"))
 		{
-			for (Map.Entry<MenuEntry, Integer> ent : originalTypes.entrySet())
-			{
-				// Honestly, I was about to write a huge ass rant about
-				// how I hate whoever wrote the menuoptionclicked class
-				// but I decided that that'd be un-nice to them, and they
-				// probably spent over 24 hours writing it. Not because
-				// it was that difficult to write, of course, but because
-				// they must have the fucking iq of a retarded, under developed,
-				// braindead, basically good-for-nothing, idiotic chimp.
-				//
-				// Just kidding, of course, that would be too big of an
-				// insult towards those poor chimps. It's not their fault
-				// some dumbass is the way they are, right? Why should they
-				// feel bad for something they can't do anything about?
-				//
-				// Whoever wrote that class though, should actually feel
-				// 100% terrible. If they aren't depressed, I really wish
-				// they become depressed very, very soon. What the fuck
-				// were they even thinking.
+			event.consume();
 
-				MenuEntry e = ent.getKey();
-
-				if (event.getMenuAction().getId() != e.getType()
-					|| event.getId() != e.getIdentifier()
-					|| !event.getMenuOption().equals(e.getOption()))
-				{
-					continue;
-				}
-
-				event.consume();
-
-				client.invokeMenuAction(
-					event.getActionParam(),
-					event.getWidgetId(),
-					ent.getValue(),
-					event.getId(),
-					event.getMenuOption(),
-					"do not edit",
-					client.getMouseCanvasPosition().getX(),
-					client.getMouseCanvasPosition().getY()
-				);
-
-				break;
-			}
+			client.invokeMenuAction(
+				event.getActionParam0(),
+				event.getActionParam1(),
+				originalTypes.get(event.getMenuEntry()),
+				event.getIdentifier(),
+				event.getOption(),
+				"do not edit",
+				client.getMouseCanvasPosition().getX(),
+				client.getMouseCanvasPosition().getY()
+			);
 		}
 
 		if (event.getMenuAction() != MenuAction.RUNELITE)
@@ -488,31 +431,31 @@ public class MenuManager
 			return; // not a player menu
 		}
 
-		int widgetId = event.getWidgetId();
+		int widgetId = event.getActionParam1();
 		Collection<WidgetMenuOption> options = managedMenuOptions.get(widgetId);
 
 		for (WidgetMenuOption curMenuOption : options)
 		{
-			if (curMenuOption.getMenuTarget().equals(event.getMenuTarget())
-				&& curMenuOption.getMenuOption().equals(event.getMenuOption()))
+			if (curMenuOption.getMenuTarget().equals(event.getTarget())
+				&& curMenuOption.getMenuOption().equals(event.getOption()))
 			{
 				WidgetMenuOptionClicked customMenu = new WidgetMenuOptionClicked();
-				customMenu.setMenuOption(event.getMenuOption());
-				customMenu.setMenuTarget(event.getMenuTarget());
+				customMenu.setMenuOption(event.getOption());
+				customMenu.setMenuTarget(event.getTarget());
 				customMenu.setWidget(curMenuOption.getWidget());
 				eventBus.post(customMenu);
 				return; // don't continue because it's not a player option
 			}
 		}
 
-		String target = event.getMenuTarget();
+		String target = event.getTarget();
 
 		// removes tags and level from player names for example:
 		// <col=ffffff>username<col=40ff00>  (level-42) or <col=ffffff><img=2>username</col>
 		String username = Text.removeTags(target).split("[(]")[0].trim();
 
 		PlayerMenuOptionClicked playerMenuOptionClicked = new PlayerMenuOptionClicked();
-		playerMenuOptionClicked.setMenuOption(event.getMenuOption());
+		playerMenuOptionClicked.setMenuOption(event.getOption());
 		playerMenuOptionClicked.setMenuTarget(username);
 
 		eventBus.post(playerMenuOptionClicked);

--- a/runelite-client/src/main/java/net/runelite/client/menus/WidgetMenuOption.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/WidgetMenuOption.java
@@ -32,15 +32,15 @@ import net.runelite.client.util.ColorUtil;
 public final class WidgetMenuOption
 {
 	/**
-	 * The left hand text to be displayed on the menu option. Ex. the menuOption of "Drop Bones" is "Drop"
+	 * The left hand text to be displayed on the menu option. Ex. the option of "Drop Bones" is "Drop"
 	 */
 	private String menuOption;
 	/**
-	 * The right hand text to be displayed on the menu option Ex. the menuTarget of "Drop Bones" is "Bones"
+	 * The right hand text to be displayed on the menu option Ex. the target of "Drop Bones" is "Bones"
 	 */
 	private String menuTarget;
 	/**
-	 * The color that the menuTarget should be. Defaults to the brownish color that most menu options have.
+	 * The color that the target should be. Defaults to the brownish color that most menu options have.
 	 */
 	private Color color = JagexColors.MENU_TARGET;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/BankTagsPlugin.java
@@ -321,12 +321,12 @@ public class BankTagsPlugin extends Plugin implements MouseWheelListener, KeyLis
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (event.getWidgetId() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
+		if (event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
 			&& event.getMenuAction() == MenuAction.RUNELITE
-			&& event.getMenuOption().startsWith(EDIT_TAGS_MENU_OPTION))
+			&& event.getOption().startsWith(EDIT_TAGS_MENU_OPTION))
 		{
 			event.consume();
-			int inventoryIndex = event.getActionParam();
+			int inventoryIndex = event.getActionParam0();
 			ItemContainer bankContainer = client.getItemContainer(InventoryID.BANK);
 			if (bankContainer == null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/banktags/tabs/TabInterface.java
@@ -231,9 +231,9 @@ public class TabInterface
 			.filter(id -> id != -1)
 			.collect(Collectors.toList());
 
-		if (!Strings.isNullOrEmpty(event.getMenuTarget()))
+		if (!Strings.isNullOrEmpty(event.getTarget()))
 		{
-			if (activeTab != null && Text.removeTags(event.getMenuTarget()).equals(activeTab.getTag()))
+			if (activeTab != null && Text.removeTags(event.getTarget()).equals(activeTab.getTag()))
 			{
 				for (Integer item : items)
 				{
@@ -565,9 +565,9 @@ public class TabInterface
 			return;
 		}
 
-		if (event.getWidgetId() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
+		if (event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
 			&& event.getMenuAction() == MenuAction.EXAMINE_ITEM_BANK_EQ
-			&& event.getMenuOption().equalsIgnoreCase("withdraw-x"))
+			&& event.getOption().equalsIgnoreCase("withdraw-x"))
 		{
 			waitSearchTick = true;
 			rememberedSearch = client.getVar(VarClientStr.INPUT_TEXT);
@@ -576,9 +576,9 @@ public class TabInterface
 
 		if (iconToSet != null)
 		{
-			if (event.getMenuOption().startsWith(CHANGE_ICON + " ("))
+			if (event.getOption().startsWith(CHANGE_ICON + " ("))
 			{
-				ItemDefinition item = getItem(event.getActionParam());
+				ItemDefinition item = getItem(event.getActionParam0());
 				int itemId = itemManager.canonicalize(item.getId());
 				iconToSet.setIconItemId(itemId);
 				iconToSet.getIcon().setItemId(itemId);
@@ -591,7 +591,7 @@ public class TabInterface
 		}
 
 		if (activeTab != null
-			&& event.getMenuOption().equals("Search")
+			&& event.getOption().equals("Search")
 			&& client.getWidget(WidgetInfo.BANK_SEARCH_BUTTON_BACKGROUND).getSpriteId() != SpriteID.EQUIPMENT_SLOT_SELECTED)
 		{
 			activateTab(null);
@@ -601,27 +601,27 @@ public class TabInterface
 			client.setVar(VarClientInt.INPUT_TYPE, 0);
 		}
 		else if (activeTab != null
-			&& event.getMenuOption().startsWith("View tab"))
+			&& event.getOption().startsWith("View tab"))
 		{
 			activateTab(null);
 		}
 		else if (activeTab != null
-			&& event.getWidgetId() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
+			&& event.getActionParam1() == WidgetInfo.BANK_ITEM_CONTAINER.getId()
 			&& event.getMenuAction() == MenuAction.RUNELITE
-			&& event.getMenuOption().startsWith(REMOVE_TAG))
+			&& event.getOption().startsWith(REMOVE_TAG))
 		{
 			// Add "remove" menu entry to all items in bank while tab is selected
 			event.consume();
-			final ItemDefinition item = getItem(event.getActionParam());
+			final ItemDefinition item = getItem(event.getActionParam0());
 			final int itemId = item.getId();
 			tagManager.removeTag(itemId, activeTab.getTag());
 			bankSearch.search(InputType.SEARCH, TAG_SEARCH + activeTab.getTag(), true);
 		}
 		else if (event.getMenuAction() == MenuAction.RUNELITE
-			&& ((event.getWidgetId() == WidgetInfo.BANK_DEPOSIT_INVENTORY.getId() && event.getMenuOption().equals(TAG_INVENTORY))
-			|| (event.getWidgetId() == WidgetInfo.BANK_DEPOSIT_EQUIPMENT.getId() && event.getMenuOption().equals(TAG_GEAR))))
+			&& ((event.getActionParam1() == WidgetInfo.BANK_DEPOSIT_INVENTORY.getId() && event.getOption().equals(TAG_INVENTORY))
+			|| (event.getActionParam1() == WidgetInfo.BANK_DEPOSIT_EQUIPMENT.getId() && event.getOption().equals(TAG_GEAR))))
 		{
-			handleDeposit(event, event.getWidgetId() == WidgetInfo.BANK_DEPOSIT_INVENTORY.getId());
+			handleDeposit(event, event.getActionParam1() == WidgetInfo.BANK_DEPOSIT_INVENTORY.getId());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/batools/BAToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/batools/BAToolsPlugin.java
@@ -707,21 +707,21 @@ public class BAToolsPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		String target = event.getMenuTarget();
+		String target = event.getTarget();
 
-		if (config.tagging() && (event.getMenuTarget().contains("Penance Ranger") || event.getMenuTarget().contains("Penance Fighter")))
+		if (config.tagging() && (event.getTarget().contains("Penance Ranger") || event.getTarget().contains("Penance Fighter")))
 		{
-			if (event.getMenuOption().contains("Attack"))
+			if (event.getOption().contains("Attack"))
 			{
-				foodPressed.put(event.getId(), Instant.now());
+				foodPressed.put(event.getIdentifier(), Instant.now());
 			}
 			log.info(target);
 		}
 
 		if (config.healerMenuOption() && target.contains("Penance Healer") && target.contains("<col=ff9040>Poisoned") && target.contains("->"))
 		{
-			foodPressed.put(event.getId(), Instant.now());
-			lastHealer = event.getId();
+			foodPressed.put(event.getIdentifier(), Instant.now());
+			lastHealer = event.getIdentifier();
 			log.info("Last healer changed: " + lastHealer);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/chathistory/ChatHistoryPlugin.java
@@ -168,7 +168,7 @@ public class ChatHistoryPlugin extends Plugin implements KeyListener
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		String menuOption = event.getMenuOption();
+		String menuOption = event.getOption();
 
 		if (menuOption.contains(CLEAR_HISTORY))
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/cluescrolls/ClueScrollPlugin.java
@@ -225,9 +225,9 @@ public class ClueScrollPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(final MenuOptionClicked event)
 	{
-		if (event.getMenuOption() != null && event.getMenuOption().equals("Read"))
+		if (event.getOption() != null && event.getOption().equals("Read"))
 		{
-			final ItemDefinition itemComposition = itemManager.getItemDefinition(event.getId());
+			final ItemDefinition itemComposition = itemManager.getItemDefinition(event.getIdentifier());
 
 			if (itemComposition != null && itemComposition.getName().startsWith("Clue scroll"))
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/examine/ExaminePlugin.java
@@ -104,7 +104,7 @@ public class ExaminePlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (!event.getMenuOption().equals("Examine"))
+		if (!event.getOption().equals("Examine"))
 		{
 			return;
 		}
@@ -116,20 +116,20 @@ public class ExaminePlugin extends Plugin
 			case EXAMINE_ITEM:
 			{
 				type = ExamineType.ITEM;
-				id = event.getId();
+				id = event.getIdentifier();
 
-				int widgetId = event.getWidgetId();
+				int widgetId = event.getActionParam1();
 				int widgetGroup = TO_GROUP(widgetId);
 				int widgetChild = TO_CHILD(widgetId);
 				Widget widget = client.getWidget(widgetGroup, widgetChild);
-				WidgetItem widgetItem = widget.getWidgetItem(event.getActionParam());
+				WidgetItem widgetItem = widget.getWidgetItem(event.getActionParam0());
 				quantity = widgetItem != null && widgetItem.getId() >= 0 ? widgetItem.getQuantity() : 1;
 				break;
 			}
 			case EXAMINE_ITEM_BANK_EQ:
 			{
 				type = ExamineType.ITEM_BANK_EQ;
-				int[] qi = findItemFromWidget(event.getWidgetId(), event.getActionParam());
+				int[] qi = findItemFromWidget(event.getActionParam1(), event.getActionParam0());
 				if (qi == null)
 				{
 					log.debug("Examine for item with unknown widget: {}", event);
@@ -141,11 +141,11 @@ public class ExaminePlugin extends Plugin
 			}
 			case EXAMINE_OBJECT:
 				type = ExamineType.OBJECT;
-				id = event.getId();
+				id = event.getIdentifier();
 				break;
 			case EXAMINE_NPC:
 				type = ExamineType.NPC;
-				id = event.getId();
+				id = event.getIdentifier();
 				break;
 			default:
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/FreezeTimersOverlay.java
@@ -119,6 +119,11 @@ public class FreezeTimersOverlay extends Overlay
 		String text = processTickCounter(finishedAt);
 		int test = Integer.parseInt(text);
 		Point poi = actor.getCanvasTextLocation(g, text, 0);
+		if (poi == null)
+		{
+			return false;
+		}
+
 		int xpoi = poi.getX();
 		int ypoi = poi.getY();
 		Point FixedPoint = new Point(xpoi, ypoi);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendnotes/FriendNotesPlugin.java
@@ -190,20 +190,20 @@ public class FriendNotesPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (WidgetInfo.TO_GROUP(event.getWidgetId()) == WidgetInfo.FRIENDS_LIST.getGroupId())
+		if (WidgetInfo.TO_GROUP(event.getActionParam1()) == WidgetInfo.FRIENDS_LIST.getGroupId())
 		{
-			if (Strings.isNullOrEmpty(event.getMenuTarget()))
+			if (Strings.isNullOrEmpty(event.getTarget()))
 			{
 				return;
 			}
 
 			// Handle clicks on "Add Note" or "Edit Note"
-			if (event.getMenuOption().equals(ADD_NOTE) || event.getMenuOption().equals(EDIT_NOTE))
+			if (event.getOption().equals(ADD_NOTE) || event.getOption().equals(EDIT_NOTE))
 			{
 				event.consume();
 
 				//Friends have color tags
-				final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getMenuTarget()));
+				final String sanitizedTarget = Text.toJagexName(Text.removeTags(event.getTarget()));
 				final String note = getFriendNote(sanitizedTarget);
 
 				// Open the new chatbox input dialog

--- a/runelite-client/src/main/java/net/runelite/client/plugins/friendtagging/FriendTaggingPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/friendtagging/FriendTaggingPlugin.java
@@ -162,16 +162,16 @@ public class FriendTaggingPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (WidgetInfo.TO_GROUP(event.getWidgetId()) == WidgetInfo.FRIENDS_LIST.getGroupId())
+		if (WidgetInfo.TO_GROUP(event.getActionParam1()) == WidgetInfo.FRIENDS_LIST.getGroupId())
 		{
-			if (Strings.isNullOrEmpty(event.getMenuTarget()))
+			if (Strings.isNullOrEmpty(event.getTarget()))
 			{
 				return;
 			}
 
-			final String sanitizedTarget = Text.removeTags(event.getMenuTarget());
+			final String sanitizedTarget = Text.removeTags(event.getTarget());
 
-			if (event.getMenuOption().equals(ADD_TAG))
+			if (event.getOption().equals(ADD_TAG))
 			{
 				event.consume();
 				final ChatboxTextInput build = chatboxPanelManager.openTextInput("Enter the tag").value("")
@@ -185,7 +185,7 @@ public class FriendTaggingPlugin extends Plugin
 						setTag(sanitizedTarget, content);
 					}).build();
 			}
-			if (event.getMenuOption().equals(DELETE_TAG))
+			if (event.getOption().equals(DELETE_TAG))
 			{
 				event.consume();
 				client.getLogger().info(sanitizedTarget);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/groundmarkers/GroundMarkerPlugin.java
@@ -315,13 +315,13 @@ public class GroundMarkerPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (!event.getMenuOption().contains(MARK) && !event.getMenuOption().contains(UNMARK))
+		if (!event.getOption().contains(MARK) && !event.getOption().contains(UNMARK))
 		{
 			return;
 		}
 
 		int group = 1;
-		Matcher m = GROUP_MATCHER.matcher(event.getMenuOption());
+		Matcher m = GROUP_MATCHER.matcher(event.getOption());
 		if (m.matches())
 		{
 			group = Integer.parseInt(m.group(1));

--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -165,15 +165,15 @@ public class InventoryTagsPlugin extends Plugin
 			return;
 		}
 
-		final String selectedMenu = Text.removeTags(event.getMenuTarget());
+		final String selectedMenu = Text.removeTags(event.getTarget());
 
-		if (event.getMenuOption().equals(MENU_SET))
+		if (event.getOption().equals(MENU_SET))
 		{
-			setTag(event.getId(), selectedMenu);
+			setTag(event.getIdentifier(), selectedMenu);
 		}
-		else if (event.getMenuOption().equals(MENU_REMOVE))
+		else if (event.getOption().equals(MENU_REMOVE))
 		{
-			unsetTag(event.getId());
+			unsetTag(event.getIdentifier());
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/kourendlibrary/KourendLibraryPlugin.java
@@ -179,9 +179,9 @@ public class KourendLibraryPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked menuOpt)
 	{
-		if (MenuAction.GAME_OBJECT_FIRST_OPTION == menuOpt.getMenuAction() && menuOpt.getMenuTarget().contains("Bookshelf"))
+		if (MenuAction.GAME_OBJECT_FIRST_OPTION == menuOpt.getMenuAction() && menuOpt.getTarget().contains("Bookshelf"))
 		{
-			lastBookcaseClick = WorldPoint.fromScene(client, menuOpt.getActionParam(), menuOpt.getWidgetId(), client.getPlane());
+			lastBookcaseClick = WorldPoint.fromScene(client, menuOpt.getActionParam0(), menuOpt.getActionParam1(), client.getPlane());
 			overlay.setHidden(false);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -474,20 +474,20 @@ public class MenuEntrySwapperPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (event.getMenuAction() != MenuAction.RUNELITE || event.getWidgetId() != WidgetInfo.INVENTORY.getId())
+		if (event.getMenuAction() != MenuAction.RUNELITE || event.getActionParam1() != WidgetInfo.INVENTORY.getId())
 		{
 			return;
 		}
 
-		int itemId = event.getId();
+		int itemId = event.getIdentifier();
 
 		if (itemId == -1)
 		{
 			return;
 		}
 
-		String option = event.getMenuOption();
-		String target = event.getMenuTarget();
+		String option = event.getOption();
+		String target = event.getTarget();
 		ItemDefinition itemComposition = client.getItemDefinition(itemId);
 
 		if (option.equals(RESET) && target.equals(MENU_TARGET))

--- a/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/motherlode/MotherlodePlugin.java
@@ -328,11 +328,11 @@ public class MotherlodePlugin extends Plugin
 			return;
 		}
 
-		if (MINE_SPOTS.contains(menu.getId()) &&  menu.getMenuAction() == MenuAction.GAME_OBJECT_FIRST_OPTION)
+		if (MINE_SPOTS.contains(menu.getIdentifier()) &&  menu.getMenuAction() == MenuAction.GAME_OBJECT_FIRST_OPTION)
 		{
 			resetIdleChecks();
-			int veinX = menu.getActionParam();
-			int veinY = menu.getWidgetId();
+			int veinX = menu.getActionParam0();
+			int veinY = menu.getActionParam1();
 			targetVeinLocation = WorldPoint.fromScene(client, veinX, veinY, client.getPlane());
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -286,13 +286,13 @@ public class NpcIndicatorsPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked click)
 	{
 		if (click.getMenuAction() != MenuAction.RUNELITE
-			|| (!click.getMenuOption().equals(TAG)
-			&& !click.getMenuOption().equals(UNTAG)))
+			|| (!click.getOption().equals(TAG)
+			&& !click.getOption().equals(UNTAG)))
 		{
 			return;
 		}
 
-		final int id = click.getId();
+		final int id = click.getIdentifier();
 		final boolean removed = npcTags.remove(id);
 		final NPC[] cachedNPCs = client.getCachedNPCs();
 		final NPC npc = cachedNPCs[id];

--- a/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/objectindicators/ObjectIndicatorsPlugin.java
@@ -272,20 +272,20 @@ public class ObjectIndicatorsPlugin extends Plugin implements KeyListener
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if (event.getMenuAction() != MenuAction.RUNELITE
-			|| (!event.getMenuOption().equals(MARK)
-			&& !event.getMenuOption().equals(UNMARK)))
+			|| (!event.getOption().equals(MARK)
+			&& !event.getOption().equals(UNMARK)))
 		{
 			return;
 		}
 
 		Scene scene = client.getScene();
 		Tile[][][] tiles = scene.getTiles();
-		final int x = event.getActionParam();
-		final int y = event.getWidgetId();
+		final int x = event.getActionParam0();
+		final int y = event.getActionParam1();
 		final int z = client.getPlane();
 		final Tile tile = tiles[z][x][y];
 
-		TileObject object = findTileObject(tile, event.getId());
+		TileObject object = findTileObject(tile, event.getIdentifier());
 		if (object == null)
 		{
 			return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/puzzlesolver/PuzzleSolverPlugin.java
@@ -138,7 +138,7 @@ public class PuzzleSolverPlugin extends Plugin
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked menuOptionClicked)
 	{
-		int widgetId = menuOptionClicked.getWidgetId();
+		int widgetId = menuOptionClicked.getActionParam1();
 		if (TO_GROUP(widgetId) != WidgetID.LIGHT_BOX_GROUP_ID)
 		{
 			return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/SlayermusiqPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/SlayermusiqPlugin.java
@@ -126,10 +126,10 @@ public class SlayermusiqPlugin extends Plugin
 	@Subscribe
 	private void onMenuOptionClicked(MenuOptionClicked ev)
 	{
-		if (ev.getMenuAction() == MenuAction.RUNELITE && ev.getMenuOption().equals(MENUOP_SLAYERMUSIQ))
+		if (ev.getMenuAction() == MenuAction.RUNELITE && ev.getOption().equals(MENUOP_SLAYERMUSIQ))
 		{
 			ev.consume();
-			String quest = Text.removeTags(ev.getMenuTarget());
+			String quest = Text.removeTags(ev.getTarget());
 			QuestGuideLinks.tryOpenGuide(quest, chatMessageManager);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/suppliestracker/SuppliesTrackerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/suppliestracker/SuppliesTrackerPlugin.java
@@ -603,23 +603,23 @@ public class SuppliesTrackerPlugin extends Plugin
 		// Create pattern to find eat/drink at beginning
 		Pattern eatPattern = Pattern.compile(EAT_PATTERN);
 		Pattern drinkPattern = Pattern.compile(DRINK_PATTERN);
-		if (eatPattern.matcher(event.getMenuTarget().toLowerCase()).find() || drinkPattern.matcher(event.getMenuTarget().toLowerCase()).find())
+		if (eatPattern.matcher(event.getTarget().toLowerCase()).find() || drinkPattern.matcher(event.getTarget().toLowerCase()).find())
 		{
 			if (actionStack.stream().noneMatch(a ->
 			{
 				if (a instanceof MenuAction.ItemAction)
 				{
 					MenuAction.ItemAction i = (MenuAction.ItemAction) a;
-					return i.getItemID() == event.getId();
+					return i.getItemID() == event.getIdentifier();
 				}
 				return false;
 			}))
 			{
 				old = client.getItemContainer(InventoryID.INVENTORY);
-				int slot = event.getActionParam();
+				int slot = event.getActionParam0();
 				if (old.getItems() != null)
 				{
-					int pushItem = old.getItems()[event.getActionParam()].getId();
+					int pushItem = old.getItems()[event.getActionParam0()].getId();
 					MenuAction newAction = new MenuAction.ItemAction(CONSUMABLE, old.getItems(), pushItem, slot);
 					actionStack.push(newAction);
 				}
@@ -629,8 +629,8 @@ public class SuppliesTrackerPlugin extends Plugin
 		// Create pattern for teleport scrolls and tabs
 		Pattern teleportPattern = Pattern.compile(TELEPORT_PATTERN);
 		Pattern teletabPattern = Pattern.compile(TELETAB_PATTERN);
-		if (teleportPattern.matcher(event.getMenuTarget().toLowerCase()).find() ||
-			teletabPattern.matcher(event.getMenuTarget().toLowerCase()).find())
+		if (teleportPattern.matcher(event.getTarget().toLowerCase()).find() ||
+			teletabPattern.matcher(event.getTarget().toLowerCase()).find())
 		{
 			old = client.getItemContainer(InventoryID.INVENTORY);
 
@@ -638,17 +638,17 @@ public class SuppliesTrackerPlugin extends Plugin
 			if (old != null && old.getItems() != null && actionStack.stream().noneMatch(a ->
 				a.getType() == TELEPORT))
 			{
-				int teleid = event.getId();
-				MenuAction newAction = new MenuAction.ItemAction(TELEPORT, old.getItems(), teleid, event.getActionParam());
+				int teleid = event.getIdentifier();
+				MenuAction newAction = new MenuAction.ItemAction(TELEPORT, old.getItems(), teleid, event.getActionParam0());
 				actionStack.push(newAction);
 			}
 		}
 
 		// Create pattern for spell cast
 		Pattern spellPattern = Pattern.compile(SPELL_PATTERN);
-		// note that here we look at the menuOption not menuTarget b/c the option for all spells is cast
+		// note that here we look at the option not target b/c the option for all spells is cast
 		// but the target differs based on each spell name
-		if (spellPattern.matcher(event.getMenuOption().toLowerCase()).find())
+		if (spellPattern.matcher(event.getOption().toLowerCase()).find())
 		{
 			old = client.getItemContainer(InventoryID.INVENTORY);
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/timers/TimersPlugin.java
@@ -396,9 +396,9 @@ public class TimersPlugin extends Plugin
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
 		if (config.showStamina()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.STAMINA_MIX1
-			|| event.getId() == ItemID.STAMINA_MIX2))
+			&& event.getOption().contains("Drink")
+			&& (event.getIdentifier() == ItemID.STAMINA_MIX1
+			|| event.getIdentifier() == ItemID.STAMINA_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(STAMINA);
@@ -406,9 +406,9 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntiFire()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.ANTIFIRE_MIX1
-			|| event.getId() == ItemID.ANTIFIRE_MIX2))
+			&& event.getOption().contains("Drink")
+			&& (event.getIdentifier() == ItemID.ANTIFIRE_MIX1
+			|| event.getIdentifier() == ItemID.ANTIFIRE_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(ANTIFIRE);
@@ -416,9 +416,9 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntiFire()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.EXTENDED_ANTIFIRE_MIX1
-			|| event.getId() == ItemID.EXTENDED_ANTIFIRE_MIX2))
+			&& event.getOption().contains("Drink")
+			&& (event.getIdentifier() == ItemID.EXTENDED_ANTIFIRE_MIX1
+			|| event.getIdentifier() == ItemID.EXTENDED_ANTIFIRE_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(EXANTIFIRE);
@@ -426,9 +426,9 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntiFire()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.SUPER_ANTIFIRE_MIX1
-			|| event.getId() == ItemID.SUPER_ANTIFIRE_MIX2))
+			&& event.getOption().contains("Drink")
+			&& (event.getIdentifier() == ItemID.SUPER_ANTIFIRE_MIX1
+			|| event.getIdentifier() == ItemID.SUPER_ANTIFIRE_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(SUPERANTIFIRE);
@@ -436,23 +436,23 @@ public class TimersPlugin extends Plugin
 		}
 
 		if (config.showAntiFire()
-			&& event.getMenuOption().contains("Drink")
-			&& (event.getId() == ItemID.EXTENDED_SUPER_ANTIFIRE_MIX1
-			|| event.getId() == ItemID.EXTENDED_SUPER_ANTIFIRE_MIX2))
+			&& event.getOption().contains("Drink")
+			&& (event.getIdentifier() == ItemID.EXTENDED_SUPER_ANTIFIRE_MIX1
+			|| event.getIdentifier() == ItemID.EXTENDED_SUPER_ANTIFIRE_MIX2))
 		{
 			// Needs menu option hook because mixes use a common drink message, distinct from their standard potion messages
 			createGameTimer(EXSUPERANTIFIRE);
 			return;
 		}
 
-		TeleportWidget teleportWidget = TeleportWidget.of(event.getWidgetId());
+		TeleportWidget teleportWidget = TeleportWidget.of(event.getActionParam1());
 		if (teleportWidget != null)
 		{
 			lastTeleportClicked = teleportWidget;
 		}
 
 		if (config.showImbuedHeart()
-			&& event.getMenuOption().contains("Invigorate"))
+			&& event.getOption().contains("Invigorate"))
 		{
 			// Needs a hook as there's a few cases where potions boost the same amount as the heart
 			imbuedHeartClicked = true;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/wiki/WikiPlugin.java
@@ -215,7 +215,7 @@ public class WikiPlugin extends Plugin
 				case SPELL_CAST_ON_GROUND_ITEM:
 				{
 					type = "item";
-					id = itemManager.canonicalize(ev.getId());
+					id = itemManager.canonicalize(ev.getIdentifier());
 					name = itemManager.getItemDefinition(id).getName();
 					location = null;
 					break;
@@ -223,7 +223,7 @@ public class WikiPlugin extends Plugin
 				case SPELL_CAST_ON_NPC:
 				{
 					type = "npc";
-					NPC npc = client.getCachedNPCs()[ev.getId()];
+					NPC npc = client.getCachedNPCs()[ev.getIdentifier()];
 					NPCDefinition nc = npc.getTransformedDefinition();
 					id = nc.getId();
 					name = nc.getName();
@@ -233,14 +233,14 @@ public class WikiPlugin extends Plugin
 				case SPELL_CAST_ON_GAME_OBJECT:
 				{
 					type = "object";
-					ObjectDefinition lc = client.getObjectDefinition(ev.getId());
+					ObjectDefinition lc = client.getObjectDefinition(ev.getIdentifier());
 					if (lc.getImpostorIds() != null)
 					{
 						lc = lc.getImpostor();
 					}
 					id = lc.getId();
 					name = lc.getName();
-					location = WorldPoint.fromScene(client, ev.getActionParam(), ev.getWidgetId(), client.getPlane());
+					location = WorldPoint.fromScene(client, ev.getActionParam0(), ev.getActionParam1(), client.getPlane());
 					break;
 				}
 				default:
@@ -272,14 +272,14 @@ public class WikiPlugin extends Plugin
 		if (ev.getMenuAction() == MenuAction.RUNELITE)
 		{
 			boolean quickguide = false;
-			switch (ev.getMenuOption())
+			switch (ev.getOption())
 			{
 				case MENUOP_QUICKGUIDE:
 					quickguide = true;
 					//fallthrough;
 				case MENUOP_GUIDE:
 					ev.consume();
-					String quest = Text.removeTags(ev.getMenuTarget());
+					String quest = Text.removeTags(ev.getTarget());
 					HttpUrl.Builder ub = WIKI_BASE.newBuilder()
 						.addPathSegment("w")
 						.addPathSegment(quest)
@@ -291,8 +291,8 @@ public class WikiPlugin extends Plugin
 					LinkBrowser.browse(ub.build().toString());
 					break;
 				case MENUOP_WIKI:
-					Matcher skillRegex = WikiPlugin.SKILL_REGEX.matcher(Text.removeTags(ev.getMenuTarget()));
-					Matcher diaryRegex = WikiPlugin.DIARY_REGEX.matcher(Text.removeTags(ev.getMenuTarget()));
+					Matcher skillRegex = WikiPlugin.SKILL_REGEX.matcher(Text.removeTags(ev.getTarget()));
+					Matcher diaryRegex = WikiPlugin.DIARY_REGEX.matcher(Text.removeTags(ev.getTarget()));
 
 					if (skillRegex.find())
 					{

--- a/runelite-client/src/main/java/net/runelite/client/rs/ClientLoader.java
+++ b/runelite-client/src/main/java/net/runelite/client/rs/ClientLoader.java
@@ -61,9 +61,8 @@ public class ClientLoader
 			switch (updateCheckMode)
 			{
 				case AUTO:
-				case CUSTOM:
-					return loadRLPlus(config);
 				default:
+					return loadRLPlus(config);
 				case VANILLA:
 					return loadVanilla(config);
 				case NONE:

--- a/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/ui/overlay/OverlayManager.java
@@ -130,13 +130,13 @@ public class OverlayManager
 
 		event.consume();
 
-		Optional<Overlay> optionalOverlay = overlays.stream().filter(o -> overlays.indexOf(o) == event.getId()).findAny();
+		Optional<Overlay> optionalOverlay = overlays.stream().filter(o -> overlays.indexOf(o) == event.getIdentifier()).findAny();
 		if (optionalOverlay.isPresent())
 		{
 			Overlay overlay = optionalOverlay.get();
 			List<OverlayMenuEntry> menuEntries = overlay.getMenuEntries();
 			Optional<OverlayMenuEntry> optionalOverlayMenuEntry = menuEntries.stream()
-				.filter(me -> me.getOption().equals(event.getMenuOption()))
+				.filter(me -> me.getOption().equals(event.getOption()))
 				.findAny();
 			if (optionalOverlayMenuEntry.isPresent())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/util/bootstrap/Bootstrapper.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/bootstrap/Bootstrapper.java
@@ -10,11 +10,9 @@ public class Bootstrapper
 	public static void main(String[] args)
 	{
 		Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-		try
+		try(FileWriter fw = new FileWriter("./bootstrap.json"))
 		{
-			FileWriter fw = new FileWriter("./bootstrap.json");
 			gson.toJson(new Bootstrap(), fw);
-			fw.close();
 		}
 		catch (Exception e)
 		{

--- a/runelite-client/src/main/java/net/runelite/client/util/bootstrap/Bootstrapper.java
+++ b/runelite-client/src/main/java/net/runelite/client/util/bootstrap/Bootstrapper.java
@@ -10,7 +10,7 @@ public class Bootstrapper
 	public static void main(String[] args)
 	{
 		Gson gson = new GsonBuilder().disableHtmlEscaping().setPrettyPrinting().create();
-		try(FileWriter fw = new FileWriter("./bootstrap.json"))
+		try (FileWriter fw = new FileWriter("./bootstrap.json"))
 		{
 			gson.toJson(new Bootstrap(), fw);
 		}

--- a/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
+++ b/runelite-client/src/test/java/net/runelite/client/plugins/examine/ExaminePluginTest.java
@@ -33,6 +33,7 @@ import net.runelite.api.ChatMessageType;
 import net.runelite.api.Client;
 import net.runelite.api.ItemID;
 import net.runelite.api.MenuAction;
+import net.runelite.api.MenuEntry;
 import net.runelite.api.events.ChatMessage;
 import net.runelite.api.events.MenuOptionClicked;
 import net.runelite.api.widgets.Widget;
@@ -88,10 +89,15 @@ public class ExaminePluginTest
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
 
-		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
-		menuOptionClicked.setMenuOption("Examine");
-		menuOptionClicked.setMenuAction(MenuAction.EXAMINE_ITEM);
-		menuOptionClicked.setId(ItemID.ABYSSAL_WHIP);
+		MenuOptionClicked menuOptionClicked = new MenuOptionClicked(new MenuEntry(
+			"Examine",
+			"Something",
+			ItemID.ABYSSAL_WHIP,
+			MenuAction.EXAMINE_ITEM.getId(),
+			123,
+			456,
+			false
+		));
 		examinePlugin.onMenuOptionClicked(menuOptionClicked);
 
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.ITEM_EXAMINE, "", "A weapon from the abyss.", "", 0);
@@ -106,10 +112,17 @@ public class ExaminePluginTest
 	{
 		when(client.getWidget(anyInt(), anyInt())).thenReturn(mock(Widget.class));
 
-		MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
-		menuOptionClicked.setMenuOption("Examine");
-		menuOptionClicked.setMenuAction(MenuAction.EXAMINE_ITEM);
-		menuOptionClicked.setId(ItemID.ABYSSAL_WHIP);
+		MenuOptionClicked menuOptionClicked = new MenuOptionClicked(new MenuEntry(
+			"Examine",
+			"Something",
+			ItemID.ABYSSAL_WHIP,
+			MenuAction.EXAMINE_ITEM.getId(),
+			123,
+			456,
+			false
+		));
+
+
 		examinePlugin.onMenuOptionClicked(menuOptionClicked);
 
 		ChatMessage chatMessage = new ChatMessage(null, ChatMessageType.ITEM_EXAMINE, "", "100000 x Abyssal whip", "", 0);

--- a/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
@@ -124,9 +124,9 @@ public abstract class MenuMixin implements RSClient
 		boolean[] menuShiftClick = getMenuForceLeftClick();
 
 		int tmp;
-		for(int i = 0; i < count; ++i)
+		for (int i = 0; i < count; ++i)
 		{
-			if(menuOpcodes[i] < 1000 && menuOpcodes[i + 1] > 1000)
+			if (menuOpcodes[i] < 1000 && menuOpcodes[i + 1] > 1000)
 			{
 				String var3 = menuTargetNames[i];
 				menuTargetNames[i] = menuTargetNames[i + 1];

--- a/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/MenuMixin.java
@@ -109,4 +109,47 @@ public abstract class MenuMixin implements RSClient
 			}
 		}
 	}
+
+	@Inject
+	@Override
+	public void sortMenuEntries()
+	{
+		int count = getMenuOptionCount() - 1;
+		int[] menuOpcodes = getMenuTypes();
+		String[] menuTargetNames = getMenuTargets();
+		String[] menuActions = getMenuOptions();
+		int[] menuArguments0 = getMenuIdentifiers();
+		int[] menuArguments1 = getMenuActionParams0();
+		int[] menuArguments2 = getMenuActionParams1();
+		boolean[] menuShiftClick = getMenuForceLeftClick();
+
+		int tmp;
+		for(int i = 0; i < count; ++i)
+		{
+			if(menuOpcodes[i] < 1000 && menuOpcodes[i + 1] > 1000)
+			{
+				String var3 = menuTargetNames[i];
+				menuTargetNames[i] = menuTargetNames[i + 1];
+				menuTargetNames[i + 1] = var3;
+				String var4 = menuActions[i];
+				menuActions[i] = menuActions[i + 1];
+				menuActions[i + 1] = var4;
+				tmp = menuOpcodes[i];
+				menuOpcodes[i] = menuOpcodes[i + 1];
+				menuOpcodes[i + 1] = tmp;
+				tmp = menuArguments1[i];
+				menuArguments1[i] = menuArguments1[i + 1];
+				menuArguments1[i + 1] = tmp;
+				tmp = menuArguments2[i];
+				menuArguments2[i] = menuArguments2[i + 1];
+				menuArguments2[i + 1] = tmp;
+				tmp = menuArguments0[i];
+				menuArguments0[i] = menuArguments0[i + 1];
+				menuArguments0[i + 1] = tmp;
+				boolean var6 = menuShiftClick[i];
+				menuShiftClick[i] = menuShiftClick[i + 1];
+				menuShiftClick[i + 1] = var6;
+			}
+		}
+	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1243,13 +1243,18 @@ public abstract class RSClientMixin implements RSClient
 			menuAction -= 2000;
 		}
 
-		final MenuOptionClicked menuOptionClicked = new MenuOptionClicked();
-		menuOptionClicked.setActionParam(actionParam);
-		menuOptionClicked.setMenuOption(menuOption);
-		menuOptionClicked.setMenuTarget(menuTarget);
-		menuOptionClicked.setMenuAction(MenuAction.of(menuAction));
-		menuOptionClicked.setId(id);
-		menuOptionClicked.setWidgetId(widgetId);
+		final MenuOptionClicked menuOptionClicked = new MenuOptionClicked(
+			new MenuEntry(
+				menuOption,
+				menuTarget,
+				id,
+				menuAction,
+				actionParam,
+				widgetId,
+				false
+			)
+		);
+
 		client.getCallbacks().post(menuOptionClicked);
 
 		if (menuOptionClicked.isConsumed())

--- a/runescape-client/src/main/java/MenuAction.java
+++ b/runescape-client/src/main/java/MenuAction.java
@@ -87,7 +87,7 @@ public class MenuAction {
       int var5;
       int var6;
       for(var5 = 0; var5 < Client.menuOptionsCount; ++var5) {
-         if(WorldMapManager.method672(Client.menuOpcodes[var5])) {
+         if(WorldMapManager.isWidgetMenuOpcode(Client.menuOpcodes[var5])) {
             if(var5 < Client.menuOptionsCount - 1) {
                for(var6 = var5; var6 < Client.menuOptionsCount - 1; ++var6) {
                   Client.menuActions[var6] = Client.menuActions[var6 + 1];

--- a/runescape-client/src/main/java/Scene.java
+++ b/runescape-client/src/main/java/Scene.java
@@ -85,8 +85,8 @@ public class Scene {
    @Export("__em_ab")
    static boolean __em_ab;
    @ObfuscatedName("ad")
-   @Export("__em_ad")
-   static int __em_ad;
+   @Export("Scene_planesCount")
+   static int Scene_planesCount;
    @ObfuscatedName("ap")
    @Export("Scene_planeOccluderCounts")
    static int[] Scene_planeOccluderCounts;
@@ -208,9 +208,9 @@ public class Scene {
       Scene_selectedX = -1;
       Scene_selectedY = -1;
       __em_ab = false;
-      __em_ad = 4;
-      Scene_planeOccluderCounts = new int[__em_ad];
-      Scene_planeOccluders = new Occluder[__em_ad][500];
+      Scene_planesCount = 4;
+      Scene_planeOccluderCounts = new int[Scene_planesCount];
+      Scene_planeOccluders = new Occluder[Scene_planesCount][500];
       Scene_currentOccludersCount = 0;
       Scene_currentOccluders = new Occluder[500];
       Scene_tilesDeque = new NodeDeque();
@@ -252,7 +252,7 @@ public class Scene {
          }
       }
 
-      for(var1 = 0; var1 < __em_ad; ++var1) {
+      for(var1 = 0; var1 < Scene_planesCount; ++var1) {
          for(var2 = 0; var2 < Scene_planeOccluderCounts[var1]; ++var2) {
             Scene_planeOccluders[var1][var2] = null;
          }

--- a/runescape-client/src/main/java/SecureRandomCallable.java
+++ b/runescape-client/src/main/java/SecureRandomCallable.java
@@ -68,7 +68,7 @@ public class SecureRandomCallable implements Callable {
       int var5;
       int var6;
       for(var5 = 0; var5 < Client.menuOptionsCount; ++var5) {
-         if(WorldMapManager.method672(Client.menuOpcodes[var5])) {
+         if(WorldMapManager.isWidgetMenuOpcode(Client.menuOpcodes[var5])) {
             if(var5 < Client.menuOptionsCount - 1) {
                for(var6 = var5; var6 < Client.menuOptionsCount - 1; ++var6) {
                   Client.menuActions[var6] = Client.menuActions[var6 + 1];

--- a/runescape-client/src/main/java/WorldMapManager.java
+++ b/runescape-client/src/main/java/WorldMapManager.java
@@ -514,7 +514,7 @@ public final class WorldMapManager {
       signature = "(II)Z",
       garbageValue = "-1344882321"
    )
-   static boolean method672(int var0) {
+   static boolean isWidgetMenuOpcode(int var0) {
       return var0 == 57 || var0 == 58 || var0 == 1007 || var0 == 25 || var0 == 30;
    }
 


### PR DESCRIPTION
This may break some swaps, but that can all be easily fixed by swapping around the 2 entries.

`client.sortMenuEntries()`
sorts the menu entries the same way the client does to determine what entry will be the left click one. As the only reason people swap menuentries is to make them left click, only the top entry is swapped, saving a lot of calculating. Priority/hidden entries are deleted on menuentryswapped still.