### PR TITLE
barbarianassault: fix remove wrong attack styles and checkstyle

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/AboveWidgetsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/AboveWidgetsOverlay.java
@@ -130,6 +130,7 @@ class AboveWidgetsOverlay extends Overlay
 
 		Rectangle spriteBounds = roleSprite.getBounds();
 		graphics.drawImage(game.getClockImage(), spriteBounds.x, spriteBounds.y, null);
+		roleSprite.setHidden(true);
 	}
 
 	private void renderInventoryHighlights(Graphics2D graphics, int itemID, Color color)
@@ -152,8 +153,8 @@ class AboveWidgetsOverlay extends Overlay
 				if (item.getQuantity() > 1)
 				{
 					OverlayUtil.renderTextLocation(graphics,
-							new Point(item.getCanvasLocation().getX() + OFFSET_X_TEXT_QUANTITY, item.getCanvasLocation().getY() + OFFSET_Y_TEXT_QUANTITY),
-							String.valueOf(item.getQuantity()), Color.YELLOW);
+						new Point(item.getCanvasLocation().getX() + OFFSET_X_TEXT_QUANTITY, item.getCanvasLocation().getY() + OFFSET_Y_TEXT_QUANTITY),
+						String.valueOf(item.getQuantity()), Color.YELLOW);
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultConfig.java
@@ -90,8 +90,8 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@Range(
-			min = 1,
-			max = 50
+		min = 1,
+		max = 50
 	)
 	@ConfigItem(
 		keyName = "prayerMetronomeVolume",
@@ -107,10 +107,10 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showDeathTimes",
-			name = "Show death times",
-			description = "Shows the time all penance monsters of a certain type are killed in the chat box, an info box, or both",
-			position = 6
+		keyName = "showDeathTimes",
+		name = "Show death times",
+		description = "Shows the time all penance monsters of a certain type are killed in the chat box, an info box, or both",
+		position = 6
 	)
 	default boolean showDeathTimes()
 	{
@@ -118,12 +118,12 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "showDeathTimesMode",
-			name = "Mode",
-			description = "",
-			position = 7,
-			hidden = true,
-			unhide = "showDeathTimes"
+		keyName = "showDeathTimesMode",
+		name = "Mode",
+		description = "",
+		position = 7,
+		hidden = true,
+		unhide = "showDeathTimes"
 	)
 	default DeathTimesMode showDeathTimesMode()
 	{
@@ -184,13 +184,13 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "attackStyles",
+		keyName = "removeIncorrectAttackStyles",
 		name = "Remove incorrect attack styles",
-		description = "Hide attack styles depending on weapon.",
+		description = "Hides wrong attack styles for dragon claws and crystal halberd",
 		position = 2,
 		group = "Attacker"
 	)
-	default boolean attackStyles()
+	default boolean removeIncorrectAttackStyles()
 	{
 		return false;
 	}
@@ -306,11 +306,11 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "highlightNotification",
-			name = "Highlight incorrect notification",
-			description = "Highlights incorrect poison chat notification",
-			position = 2,
-			group = "Healer"
+		keyName = "highlightNotification",
+		name = "Highlight incorrect notification",
+		description = "Highlights incorrect poison chat notification",
+		position = 2,
+		group = "Healer"
 	)
 	default boolean highlightNotification()
 	{
@@ -318,13 +318,13 @@ public interface BarbarianAssaultConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "highlightNotificationColor",
-			name = "Notification color",
-			description = "Configures the color to highlight the notification text",
-			position = 3,
-			group = "Healer",
-			hidden = true,
-			unhide = "highlightNotification"
+		keyName = "highlightNotificationColor",
+		name = "Notification color",
+		description = "Configures the color to highlight the notification text",
+		position = 3,
+		group = "Healer",
+		hidden = true,
+		unhide = "highlightNotification"
 	)
 	default Color highlightNotificationColor()
 	{


### PR DESCRIPTION
Can confirm removing the wrong attack styles actually works now. Right now it only hides wrong styles for the crystal halberd and dragon claws as that is how it worked before. It would, however, be very easy to allow any weapon to have its wrong styles hidden - if that's something people want.