### PR TITLE
barbarianassault: fix horn hidden entry hiding non ba items

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultMenu.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/BarbarianAssaultMenu.java
@@ -174,7 +174,7 @@ class BarbarianAssaultMenu
 					return config.removeIncorrectCalls() && !hornUpdated;
 
 				default:
-					return config.removeUnusedMenus();
+					return role != null && config.removeUnusedMenus();
 			}
 		});
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Menus.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/barbarianassault/Menus.java
@@ -79,11 +79,11 @@ public enum Menus
 
 	ATTACK_PENANCE_QUEEN(null, new ComparableEntry("attack", "penance queen", -1, -1, true, false)),
 	ATTACK_QUEEN_SPAWN(null, new ComparableEntry("attack", "queen spawn", -1, -1, true, false)),
-	DROP_HORN(null, new ComparableEntry("drop", "horn", -1, -1, true, false)),
-	EXAMINE_HORN(null, new ComparableEntry("examine", "horn", -1, -1, true, false)),
+	DROP_HORN(null, new ComparableEntry("drop", "r horn", -1, -1, true, false)),
+	EXAMINE_HORN(null, new ComparableEntry("examine", "r horn", -1, -1, true, false)),
 	LIGHT_LOGS(null, new ComparableEntry("light", "logs", -1, -1, true, true)),
-	MEDIC_HORN(null, new ComparableEntry("medic", "horn", -1, -1, true, false)),
-	USE_HORN(null, new ComparableEntry("use", "horn", -1, -1, true, false));
+	MEDIC_HORN(null, new ComparableEntry("medic", "r horn", -1, -1, true, false)),
+	USE_HORN(null, new ComparableEntry("use", "r horn", -1, -1, true, false));
 
 	@Getter
 	private final Role role;


### PR DESCRIPTION
Made hidden entries more specific so that they only applies to horns available in barbarian assault and rechecked the list of hidden entries to make sure this wouldn't happen with anything else.
Fixes issue #848 