### PR TITLE
runeliteapi: add timeout to rlp api call.

### DIFF
--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -105,7 +105,6 @@ public class RuneLiteAPI
 			.pingInterval(30, TimeUnit.SECONDS)
 			.connectTimeout(5655, TimeUnit.MILLISECONDS)
 			.writeTimeout(5655, TimeUnit.MILLISECONDS)
-			.connectTimeout(5655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()
 			{
 				@Override
@@ -122,7 +121,6 @@ public class RuneLiteAPI
 
 		RLP_CLIENT = new OkHttpClient.Builder()
 			.pingInterval(30, TimeUnit.SECONDS)
-			.connectTimeout(5655, TimeUnit.MILLISECONDS)
 			.writeTimeout(5655, TimeUnit.MILLISECONDS)
 			.connectTimeout(2655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -119,6 +119,7 @@ public class RuneLiteAPI
 
 		RLP_CLIENT = new OkHttpClient.Builder()
 			.pingInterval(30, TimeUnit.SECONDS)
+			.connectTimeout(2655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()
 			{
 				@Override

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -104,6 +104,8 @@ public class RuneLiteAPI
 		CLIENT = new OkHttpClient.Builder()
 			.pingInterval(30, TimeUnit.SECONDS)
 			.connectTimeout(5655, TimeUnit.MILLISECONDS)
+			.writeTimeout(5655, TimeUnit.MILLISECONDS)
+			.connectTimeout(5655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()
 			{
 				@Override
@@ -120,6 +122,8 @@ public class RuneLiteAPI
 
 		RLP_CLIENT = new OkHttpClient.Builder()
 			.pingInterval(30, TimeUnit.SECONDS)
+			.connectTimeout(5655, TimeUnit.MILLISECONDS)
+			.writeTimeout(5655, TimeUnit.MILLISECONDS)
 			.connectTimeout(2655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()
 			{

--- a/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
+++ b/http-api/src/main/java/net/runelite/http/api/RuneLiteAPI.java
@@ -103,6 +103,7 @@ public class RuneLiteAPI
 
 		CLIENT = new OkHttpClient.Builder()
 			.pingInterval(30, TimeUnit.SECONDS)
+			.connectTimeout(5655, TimeUnit.MILLISECONDS)
 			.addNetworkInterceptor(new Interceptor()
 			{
 				@Override

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
 		<mockito.version>1.10.19</mockito.version>
 		<sql2o.version>1.5.4</sql2o.version>
 		<minio.version>3.0.6</minio.version>
-		<okhttp3.version>3.7.0</okhttp3.version>
+		<okhttp3.version>4.0.0</okhttp3.version>
 		<zlika.reproducible.build.maven.plugin.version>0.7</zlika.reproducible.build.maven.plugin.version>
 
 		<maven.jar.plugin.version>3.0.2</maven.jar.plugin.version>


### PR DESCRIPTION
Updated okhttp3 from 3.7.0 to okhttp3 4.0.0
Added timeout stuff

Tested on my fast connection, !price seems faster/less/no microstutter
Needs to be tested on a slow connection, justin was talking about how he had a firewall and it would freeze his client for 15 seconds. Maybe he can test.