### PR TITLE
pluginsorter: fix runelite plugin incorrect position when unhiding plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/pluginsorter/PluginSorterPlugin.java
@@ -163,8 +163,8 @@ public class PluginSorterPlugin extends Plugin
 	private void showPlugins()
 	{
 		List<PluginListItem> tempList = new ArrayList<>();
-		tempList.addAll(removedPlugins);
 		tempList.addAll(ConfigPanel.pluginList);
+		tempList.addAll(1, removedPlugins);
 		ConfigPanel.pluginList = tempList;
 	}
 }


### PR DESCRIPTION
Fixes issue #569