### PR TITLE
menumanager: fix NoElementException

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -796,7 +796,7 @@ public class MenuManager
 		leftClickEntry = Iterables.getLast(safeCurrentPriorityEntries.entrySet().stream()
 			.sorted(Comparator.comparingInt(e -> e.getValue().getPriority()))
 			.map(Map.Entry::getKey)
-			.collect(Collectors.toList()));
+			.collect(Collectors.toList()), null);
 	}
 
 	private void indexSwapEntries(Set<MenuEntry>  entries)


### PR DESCRIPTION
@tomcylke was getting a [NoSuchElementException](https://gyazo.com/0b34afc80add6800dd74ad0c97bccb85) because Google's Iterables class throws an exception when you call getLast() with an emply list as the parameter, unless you include a default value.

It now has a default value of null, which is the correct value it should be if the list is empty.