### PR TITLE
menumanager: fix slow swaps

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -287,6 +287,11 @@ public class MenuManager
 			return;
 		}
 
+		rebuildLeftClickMenu();
+	}
+
+	private void rebuildLeftClickMenu()
+	{
 		entries.clear();
 		entries.addAll(Arrays.asList(client.getMenuEntries()));
 
@@ -428,10 +433,15 @@ public class MenuManager
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (!client.isMenuOpen() && leftClickEntry != null)
+		if (!client.isMenuOpen())
 		{
-			event.setMenuEntry(leftClickEntry);
-			leftClickEntry = null;
+			rebuildLeftClickMenu();
+
+			if (leftClickEntry != null)
+			{
+				event.setMenuEntry(leftClickEntry);
+				leftClickEntry = null;
+			}
 		}
 
 		if (event.getMenuAction() != MenuAction.RUNELITE)


### PR DESCRIPTION
The left click entry was being cleared every time an option was clicked, but because the left click menu is being built before each render instead of every time an entry is added to the menu, if you clicked more than once per render the second click would not be swapped. This changes it so that the menu is also rebuilt every click to fix slow swaps.

Fixes #819

Examples:
[Before fix](https://gyazo.com/79a1d030b4456de24f01b63e61638e28)

[After fix](https://gyazo.com/8126435ff97eba4322186b085c9e8aad)