### PR TITLE
menumanager: fix hidden entries

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -325,8 +325,13 @@ public class MenuManager
 		{
 			entries.remove(leftClickEntry);
 			entries.add(leftClickEntry);
-			client.setMenuEntries(entries.toArray(new MenuEntry[0]));
 		}
+		else if (!currentHiddenEntries.isEmpty())
+		{
+			leftClickEntry = Iterables.getLast(entries, null);
+		}
+
+		client.setMenuEntries(entries.toArray(new MenuEntry[0]));
 	}
 
 	public void addPlayerMenuItem(String menuText)


### PR DESCRIPTION
Murphy's law appears to be working its magic. I'm just fixing the bugs as they come up, hopefully this is the last one.

The problem with this one was that hidden entries were never actually being removed from the left click menu. Fixes barbarian assault horn not having correct left click option and fixes hidden entries in general.