### PR TITLE
menuentryadded: fix incorrect type/identifier

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorytags/InventoryTagsPlugin.java
@@ -227,6 +227,8 @@ public class InventoryTagsPlugin extends Plugin
 				menuList[num++] = newMenu;
 			}
 
+			// Need to set the event entries to prevent conflicts
+			event.setMenuEntries(menuList);
 			client.setMenuEntries(menuList);
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -332,11 +332,13 @@ public class NpcIndicatorsPlugin extends Plugin
 			if (mn != null && isNpcMemorizationUnnecessary(mn))
 			{
 				memorizedNpcs.remove(npc.getIndex());
+				rebuildAllNpcs();
 			}
 		}
 		else
 		{
 			npcTags.add(id);
+			rebuildAllNpcs();
 		}
 
 		click.consume();

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -650,8 +650,8 @@ public abstract class RSClientMixin implements RSClient
 				new MenuEntry(
 					client.getMenuOptions()[oldCount],
 					client.getMenuTargets()[oldCount],
-					client.getMenuTypes()[oldCount],
 					client.getMenuIdentifiers()[oldCount],
+					client.getMenuTypes()[oldCount],
 					client.getMenuActionParams0()[oldCount],
 					client.getMenuActionParams1()[oldCount],
 					client.getMenuForceLeftClick()[oldCount]


### PR DESCRIPTION
I have updated the posting of menuentryadded to use the correct type/identifier parameters. I'm slowly working through the plugins that use menuentryadded which is I think 30 or so plugins. I'll push commits as I verify that they are working. If you know of any specific plugins that were changed to "fix" them please save me some time looking through the previous commits and let me know.


Edit: I went through the commit history and narrowed down the list of possibly affected plugins to the following:
- [x] Bank Tags
- [x] Chat Translator
- [x] Corp
- [x] Dev Tools
- [x] Friend Notes
- [x] Friend Tagging
- [x] Ground Items
- [x] Ground Markers
- [x] Inventory Tags
- [ ] MenuEntrySwapper
- [x] NPC Indicators
- [x] PvP Tools
- [ ] Object Indicators
- [x] Slayermusiq
- [x] Wiki