### PR TITLE
menuentryclicked: add isauthentic field

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/MenuOptionClicked.java
@@ -24,7 +24,9 @@
  */
 package net.runelite.api.events;
 
+import lombok.AccessLevel;
 import lombok.Data;
+import lombok.Setter;
 import net.runelite.api.MenuAction;
 import net.runelite.api.MenuEntry;
 
@@ -45,6 +47,13 @@ public class MenuOptionClicked
 	public MenuOptionClicked(MenuEntry entry)
 	{
 		menuEntry = entry;
+		authentic = true;
+	}
+
+	public MenuOptionClicked(MenuEntry entry, boolean authentic)
+	{
+		menuEntry = entry;
+		this.authentic = authentic;
 	}
 
 	/**
@@ -129,4 +138,10 @@ public class MenuOptionClicked
 	{
 		this.consumed = true;
 	}
+
+	/**
+	 * Whether or not the event is authentic.
+	 */
+	@Setter(AccessLevel.PRIVATE)
+	private boolean authentic;
 }

--- a/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/menus/MenuManager.java
@@ -438,7 +438,7 @@ public class MenuManager
 	@Subscribe
 	public void onMenuOptionClicked(MenuOptionClicked event)
 	{
-		if (!client.isMenuOpen())
+		if (!client.isMenuOpen() && event.isAuthentic())
 		{
 			rebuildLeftClickMenu();
 

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1253,9 +1253,16 @@ public abstract class RSClientMixin implements RSClient
 	@Replace("menuAction")
 	static void rl$menuAction(int actionParam, int widgetId, int menuAction, int id, String menuOption, String menuTarget, int var6, int var7)
 	{
+		boolean authentic = true;
+		if (menuTarget != null && menuTarget.startsWith("!AUTHENTIC"))
+		{
+			authentic = false;
+			menuTarget = menuTarget.substring(10);
+		}
+
 		if (printMenuActions && client.getLogger().isDebugEnabled())
 		{
-			client.getLogger().debug("Menuaction: {} {} {} {} {} {} {} {}", actionParam, widgetId, menuAction, id, menuOption, menuTarget, var6, var7);
+			client.getLogger().debug("Menuaction: {} {} {} {} {} {} {} {} {}", actionParam, widgetId, menuAction, id, menuOption, menuTarget, var6, var7, authentic);
 		}
 
 		/* Along the way, the RuneScape client may change a menuAction by incrementing it with 2000.
@@ -1275,7 +1282,8 @@ public abstract class RSClientMixin implements RSClient
 				actionParam,
 				widgetId,
 				false
-			)
+			),
+			authentic
 		);
 
 		client.getCallbacks().post(menuOptionClicked);
@@ -1287,6 +1295,13 @@ public abstract class RSClientMixin implements RSClient
 
 		rs$menuAction(menuOptionClicked.getActionParam0(), menuOptionClicked.getActionParam1(), menuOptionClicked.getType(),
 			menuOptionClicked.getIdentifier(), menuOptionClicked.getOption(), menuOptionClicked.getTarget(), var6, var7);
+	}
+
+	@Override
+	@Inject
+	public void invokeMenuAction(int actionParam, int widgetId, int menuAction, int id, String menuOption, String menuTarget, int var6, int var7)
+	{
+		client.sendMenuAction(actionParam, widgetId, menuAction, id, menuOption, "!AUTHENTIC" + menuTarget, var6, var7);
 	}
 
 	@FieldHook("Login_username")

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -390,8 +390,7 @@ public interface RSClient extends RSGameShell, Client
 	RSSprite createItemSprite(int itemId, int quantity, int thickness, int borderColor, int stackable, boolean noted);
 
 	@Import("menuAction")
-	@Override
-	void invokeMenuAction(int n2, int n3, int n4, int n5, String string, String string2, int n6, int n7);
+	void sendMenuAction(int n2, int n3, int n4, int n5, String string, String string2, int n6, int n7);
 
 	@Import("decodeSprite")
 	void decodeSprite(byte[] data);


### PR DESCRIPTION
MenuManager was intercepting all clicks and setting what it should be after hiding/prioritizing/swapping entries in the current menu, this works fine unless another plugin invokes a menuaction such as the world hopper plugin, or an external plugin. This pr adds a flag to MenuOptionClicked events allowing MenuManager to differentiate between authentic clicks and invoked clicks.

Fixes #906 