### PR TITLE
safespot: stops the safespot overlay from rendering when it's not supposed to.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/safespot/SafeSpotPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/safespot/SafeSpotPlugin.java
@@ -119,14 +119,13 @@ public class SafeSpotPlugin extends Plugin
 				updateSafeSpots();
 			}
 		}
+		else if (tickCount > 0)
+		{
+			tickCount--;
+		}
 		else
 		{
 			safeSpotsRenderable = false;
-		}
-		if (tickCount > 0)
-		{
-			tickCount--;
-			safeSpotsRenderable = true;
 		}
 	}
 


### PR DESCRIPTION
Before this, you could for example get this bug:
Have player safespots turned on and NPC safespots turned off.
Interact with another player, which creates a safespotlist.
After this, whenever you're interacting with an NPC and then stop
interacting with it, the overlay would turn on with the tiles from the
old playerinteraction safespotlist rendered for 10 ticks.