### PR TITLE
grounditems: revert "Fix ground item menu color"

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -675,9 +675,9 @@ public class GroundItemsPlugin extends Plugin
 	{
 		if (this.itemHighlightMode != OVERLAY
 			&& event.getOption().equals("Take")
-			&& event.getIdentifier() == THIRD_OPTION)
+			&& event.getType() == THIRD_OPTION)
 		{
-			int itemId = event.getType();
+			int itemId = event.getIdentifier();
 			Scene scene = client.getScene();
 			Tile tile = scene.getTiles()[client.getPlane()][event.getActionParam0()][event.getActionParam1()];
 			ItemLayer itemLayer = tile.getItemLayer();


### PR DESCRIPTION
Type/Identifiers were switched back so this fix should be reverted.