### PR TITLE
npcstatus: Add custom attack speed option. Some fixes/improvements.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/MemorizedNPC.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/MemorizedNPC.java
@@ -52,8 +52,6 @@ class MemorizedNPC
 	private WorldArea lastnpcarea;
 	@Setter(AccessLevel.PACKAGE)
 	private Actor lastinteracted;
-	@Setter(AccessLevel.PACKAGE)
-	private int lastspotanimation;
 
 	MemorizedNPC(final NPC npc, final int attackSpeed, final WorldArea worldArea)
 	{
@@ -67,7 +65,6 @@ class MemorizedNPC
 		this.status = Status.OUT_OF_COMBAT;
 		this.lastnpcarea = worldArea;
 		this.lastinteracted = null;
-		this.lastspotanimation = -1;
 	}
 
 	@Getter(AccessLevel.PACKAGE)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
@@ -27,17 +27,49 @@ package net.runelite.client.plugins.npcstatus;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("npcstatus")
 public interface NpcStatusConfig extends Config
 {
+	@Range(
+			min = 1
+	)
 	@ConfigItem(
 		keyName = "AttackRange",
-		name = "NPC Attack range",
-		description = "The attack range of the NPC"
+		name = "NPC attack range",
+		description = "The attack range of the NPC.",
+		position = 1
 	)
 	default int getRange()
 	{
 		return 1;
+	}
+
+	@ConfigItem(
+			keyName = "CustomAttSpeedEnabled",
+			name = "Custom attack speed",
+			description = "Use this if the timer is wrong.",
+			position = 2
+	)
+	default boolean isCustomAttSpeed()
+	{
+		return false;
+	}
+
+	@Range(
+			min = 1
+	)
+	@ConfigItem(
+			keyName = "CustomAttSpeed",
+			name = "Custom NPC att speed",
+			description = "The attack speed of the NPC (amount of ticks between their attacks).",
+			position = 3,
+			hidden = true,
+			unhide = "CustomAttSpeedEnabled"
+	)
+	default int getCustomAttSpeed()
+	{
+		return 4;
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
@@ -47,10 +47,10 @@ public interface NpcStatusConfig extends Config
 	}
 
 	@ConfigItem(
-			keyName = "CustomAttSpeedEnabled",
-			name = "Custom attack speed",
-			description = "Use this if the timer is wrong.",
-			position = 2
+		keyName = "CustomAttSpeedEnabled",
+		name = "Custom attack speed",
+		description = "Use this if the timer is wrong.",
+		position = 2
 	)
 	default boolean isCustomAttSpeed()
 	{
@@ -58,15 +58,15 @@ public interface NpcStatusConfig extends Config
 	}
 
 	@Range(
-			min = 1
+		min = 1
 	)
 	@ConfigItem(
-			keyName = "CustomAttSpeed",
-			name = "Custom NPC att speed",
-			description = "The attack speed of the NPC (amount of ticks between their attacks).",
-			position = 3,
-			hidden = true,
-			unhide = "CustomAttSpeedEnabled"
+		keyName = "CustomAttSpeed",
+		name = "Custom NPC att speed",
+		description = "The attack speed of the NPC (amount of ticks between their attacks).",
+		position = 3,
+		hidden = true,
+		unhide = "CustomAttSpeedEnabled"
 	)
 	default int getCustomAttSpeed()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusConfig.java
@@ -33,7 +33,7 @@ import net.runelite.client.config.Range;
 public interface NpcStatusConfig extends Config
 {
 	@Range(
-			min = 1
+		min = 1
 	)
 	@ConfigItem(
 		keyName = "AttackRange",

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusOverlay.java
@@ -55,10 +55,6 @@ public class NpcStatusOverlay extends Overlay
 	{
 		for (MemorizedNPC npc : plugin.getMemorizedNPCs())
 		{
-			if ((npc.getNpc().getInteracting() == null && client.getLocalPlayer().getInteracting() == null))
-			{
-				continue;
-			}
 			if (npc.getNpc().getInteracting() == client.getLocalPlayer() || client.getLocalPlayer().getInteracting() == npc.getNpc())
 			{
 				switch (npc.getStatus())

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusOverlay.java
@@ -55,7 +55,7 @@ public class NpcStatusOverlay extends Overlay
 	{
 		for (MemorizedNPC npc : plugin.getMemorizedNPCs())
 		{
-			if (npc.getNpc().getInteracting() == null)
+			if ((npc.getNpc().getInteracting() == null && client.getLocalPlayer().getInteracting() == null))
 			{
 				continue;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
@@ -159,6 +159,10 @@ public class NpcStatusPlugin extends Plugin
 		{
 			for (MemorizedNPC mn : memorizedNPCs)
 			{
+				if (mn.getNpcIndex() != ((NPC) event.getActor()).getIndex())
+				{
+					continue;
+				}
 				if (mn.getStatus() == MemorizedNPC.Status.OUT_OF_COMBAT || (mn.getStatus() == MemorizedNPC.Status.IN_COMBAT && mn.getCombatTimerEnd() - client.getTickCount() < 1) || mn.getLastinteracted() == null)
 				{
 					mn.setStatus(MemorizedNPC.Status.FLINCHING);
@@ -184,7 +188,11 @@ public class NpcStatusPlugin extends Plugin
 		{
 			for (MemorizedNPC mn : memorizedNPCs)
 			{
-				if (mn.getStatus() == MemorizedNPC.Status.OUT_OF_COMBAT || (mn.getStatus() == MemorizedNPC.Status.IN_COMBAT && mn.getCombatTimerEnd() - client.getTickCount() < 2) || mn.getLastinteracted() == null)
+				if (mn.getNpcIndex() != ((NPC) event.getActor()).getIndex())
+				{
+					continue;
+				}
+				if (mn.getStatus() == MemorizedNPC.Status.OUT_OF_COMBAT || (mn.getStatus() == MemorizedNPC.Status.IN_COMBAT && mn.getCombatTimerEnd() - client.getTickCount() < 2) || event.getActor().getInteracting() == null)
 				{
 					mn.setStatus(MemorizedNPC.Status.FLINCHING);
 					mn.setCombatTimerEnd(-1);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
@@ -203,6 +203,10 @@ public class NpcStatusPlugin extends Plugin
 
 	private void checkStatus()
 	{
+		if (lastPlayerLocation == null)
+		{
+			return;
+		}
 		for (MemorizedNPC npc : memorizedNPCs)
 		{
 			final double CombatTime = npc.getCombatTimerEnd() - client.getTickCount();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npcstatus/NpcStatusPlugin.java
@@ -25,7 +25,6 @@
 package net.runelite.client.plugins.npcstatus;
 
 import com.google.inject.Provides;
-import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -46,6 +45,7 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.NpcDespawned;
 import net.runelite.api.events.NpcSpawned;
+import net.runelite.api.events.SpotAnimationChanged;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.game.NPCManager;
@@ -65,9 +65,6 @@ import net.runelite.client.ui.overlay.OverlayManager;
 @Singleton
 public class NpcStatusPlugin extends Plugin
 {
-	@Getter(AccessLevel.PACKAGE)
-	private final Set<MemorizedNPC> memorizedNPCs = new HashSet<>();
-
 	@Inject
 	private Client client;
 
@@ -84,11 +81,16 @@ public class NpcStatusPlugin extends Plugin
 	private NpcStatusOverlay npcStatusOverlay;
 
 	@Getter(AccessLevel.PACKAGE)
-	private Instant lastTickUpdate;
+	private final Set<MemorizedNPC> memorizedNPCs = new HashSet<>();
 
-	private WorldArea lastPlayerLocation;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isCustomAttSpeed;
+
+	private int getCustomAttSpeed;
 
 	private int getRange;
+
+	private WorldArea lastPlayerLocation;
 
 	@Provides
 	NpcStatusConfig provideConfig(ConfigManager configManager)
@@ -120,7 +122,12 @@ public class NpcStatusPlugin extends Plugin
 		{
 			return;
 		}
-		memorizedNPCs.add(new MemorizedNPC(npc, npcManager.getAttackSpeed(npc.getId()), npc.getWorldArea()));
+		int AttackSpeed = npcManager.getAttackSpeed(npc.getId());
+		if (AttackSpeed == 0)
+		{
+			AttackSpeed = 4;
+		}
+		memorizedNPCs.add(new MemorizedNPC(npc, AttackSpeed, npc.getWorldArea()));
 	}
 
 	@Subscribe
@@ -156,18 +163,48 @@ public class NpcStatusPlugin extends Plugin
 				{
 					mn.setStatus(MemorizedNPC.Status.FLINCHING);
 					mn.setCombatTimerEnd(-1);
-					mn.setFlinchTimerEnd(client.getTickCount() + mn.getAttackSpeed() / 2 + 1);
+					if (isCustomAttSpeed())
+					{
+						mn.setFlinchTimerEnd(client.getTickCount() + getCustomAttSpeed / 2 + 1);
+					}
+					else
+					{
+						mn.setFlinchTimerEnd(client.getTickCount() + mn.getAttackSpeed() / 2 + 1);
+					}
 				}
 			}
 		}
 
 	}
 
+	@Subscribe
+	public void onSpotAnimationChanged(SpotAnimationChanged event)
+	{
+		if ((event.getActor().getSpotAnimation() == GraphicID.SPLASH) && event.getActor() instanceof NPC)
+		{
+			for (MemorizedNPC mn : memorizedNPCs)
+			{
+				if (mn.getStatus() == MemorizedNPC.Status.OUT_OF_COMBAT || (mn.getStatus() == MemorizedNPC.Status.IN_COMBAT && mn.getCombatTimerEnd() - client.getTickCount() < 2) || mn.getLastinteracted() == null)
+				{
+					mn.setStatus(MemorizedNPC.Status.FLINCHING);
+					mn.setCombatTimerEnd(-1);
+					if (isCustomAttSpeed())
+					{
+						mn.setFlinchTimerEnd(client.getTickCount() + getCustomAttSpeed / 2 + 2);
+					}
+					else
+					{
+						mn.setFlinchTimerEnd(client.getTickCount() + mn.getAttackSpeed() / 2 + 2);
+					}
+				}
+			}
+		}
+	}
+
 	private void checkStatus()
 	{
 		for (MemorizedNPC npc : memorizedNPCs)
 		{
-			final int ATTACK_SPEED = npc.getAttackSpeed();
 			final double CombatTime = npc.getCombatTimerEnd() - client.getTickCount();
 			final double FlinchTime = npc.getFlinchTimerEnd() - client.getTickCount();
 			if (npc.getNpc().getWorldArea() == null)
@@ -176,19 +213,6 @@ public class NpcStatusPlugin extends Plugin
 			}
 			if (npc.getNpc().getInteracting() == client.getLocalPlayer())
 			{
-				if (npc.getLastspotanimation() == GraphicID.SPLASH && npc.getNpc().getSpotAnimation() == GraphicID.SPLASH) //For splash flinching
-				{
-					npc.setLastspotanimation(-1);
-					if ((npc.getStatus() == MemorizedNPC.Status.OUT_OF_COMBAT) || npc.getLastinteracted() == null)
-					{
-						npc.setStatus(MemorizedNPC.Status.FLINCHING);
-						npc.setCombatTimerEnd(-1);
-						npc.setFlinchTimerEnd(client.getTickCount() + ATTACK_SPEED / 2 + 1);
-						npc.setLastnpcarea(npc.getNpc().getWorldArea());
-						npc.setLastinteracted(npc.getNpc().getInteracting());
-						continue;
-					}
-				}
 				//Checks: will the NPC attack this tick?
 				if (((npc.getNpc().getWorldArea().canMelee(client, lastPlayerLocation) && this.getRange == 1) //Separate mechanics for meleerange-only NPC's because they have extra collisiondata checks (fences etc.) and can't attack diagonally
 					|| (lastPlayerLocation.hasLineOfSightTo(client, npc.getNpc().getWorldArea()) && npc.getNpc().getWorldArea().distanceTo(lastPlayerLocation) <= this.getRange && this.getRange > 1))
@@ -196,11 +220,17 @@ public class NpcStatusPlugin extends Plugin
 					&& npc.getNpc().getAnimation() != -1 //Failsafe, attacking NPC's always have an animation.
 					&& !(npc.getLastnpcarea().distanceTo(lastPlayerLocation) == 0 && npc.getLastnpcarea() != npc.getNpc().getWorldArea())) //Weird mechanic: NPC's can't attack on the tick they do a random move
 				{
-					npc.setCombatTimerEnd(client.getTickCount() + ATTACK_SPEED + 8);
 					npc.setStatus(MemorizedNPC.Status.IN_COMBAT_DELAY);
 					npc.setLastnpcarea(npc.getNpc().getWorldArea());
-					npc.setLastspotanimation(npc.getNpc().getSpotAnimation());
 					npc.setLastinteracted(npc.getNpc().getInteracting());
+					if (isCustomAttSpeed())
+					{
+						npc.setCombatTimerEnd(client.getTickCount() + getCustomAttSpeed + 8);
+					}
+					else
+					{
+						npc.setCombatTimerEnd(client.getTickCount() + npc.getAttackSpeed() + 8);
+					}
 					continue;
 				}
 			}
@@ -226,7 +256,6 @@ public class NpcStatusPlugin extends Plugin
 					}
 			}
 			npc.setLastnpcarea(npc.getNpc().getWorldArea());
-			npc.setLastspotanimation(npc.getNpc().getSpotAnimation());
 			npc.setLastinteracted(npc.getNpc().getInteracting());
 		}
 	}
@@ -234,7 +263,6 @@ public class NpcStatusPlugin extends Plugin
 	@Subscribe
 	public void onGameTick(GameTick event)
 	{
-		lastTickUpdate = Instant.now();
 		checkStatus();
 		lastPlayerLocation = client.getLocalPlayer().getWorldArea();
 	}
@@ -248,5 +276,7 @@ public class NpcStatusPlugin extends Plugin
 		}
 
 		this.getRange = config.getRange();
+		this.isCustomAttSpeed = config.isCustomAttSpeed();
+		this.getCustomAttSpeed = config.getCustomAttSpeed();
 	}
 }


### PR DESCRIPTION
Implement optional custom attack speed as config option, useful because the npc
stats data we have from wiki isn't 100% correct, or isn't even there sometimes.
Add minimum attackrange of 1.
Render timer when the player is interacting with an NPC.
Add default attack speed of 4 when wiki doesn't provide the data.
Fix splash flinching while using a better method to implement it, using
the function "onSpotAnimationChanged".
Remove deprecated variable "lastspotanimation".
Remove unused variable "lastTickUpdate".