### PR TITLE
Inventory Grid Plugin: Make it so the grid/background actually works

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/inventorygrid/InventoryGridOverlay.java
@@ -69,7 +69,7 @@ class InventoryGridOverlay extends Overlay
 		final Widget if1DraggingWidget = client.getIf1DraggedWidget();
 		final Widget inventoryWidget = client.getWidget(WidgetInfo.INVENTORY);
 
-		if (if1DraggingWidget == null || if1DraggingWidget.equals(inventoryWidget)
+		if (if1DraggingWidget == null || if1DraggingWidget != inventoryWidget
 			|| client.getItemPressedDuration() < plugin.getDragDelay() / Constants.CLIENT_TICK_LENGTH)
 		{
 			return null;


### PR DESCRIPTION
The way it was being done before was the correct way, this commit https://github.com/runelite-extended/runelite/commit/d6285235cb836d90c09dae22e686a113bef88c4d actually broke it. So this reverts it back to the original method.

Closes #974 