### PR TITLE
Status Orb Plugin: Fix run energy overlay

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/statusorbs/StatusOrbsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/statusorbs/StatusOrbsOverlay.java
@@ -139,49 +139,46 @@ public class StatusOrbsOverlay extends Overlay
 			renderRegen(g, WidgetInfo.MINIMAP_SPEC_ORB, percentSpec, SPECIAL_COLOR);
 		}
 
-		if (plugin.isReplaceOrbText())
+		final Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_TOGGLE_RUN_ORB);
+
+		if (runOrb == null || runOrb.isHidden())
 		{
-			final Widget runOrb = client.getWidget(WidgetInfo.MINIMAP_TOGGLE_RUN_ORB);
+			return null;
+		}
 
-			if (runOrb == null || runOrb.isHidden())
+		final Rectangle bounds = runOrb.getBounds();
+
+		if (bounds.getX() <= 0)
+		{
+			return null;
+		}
+
+		final Point mousePosition = client.getMouseCanvasPosition();
+
+		if (bounds.contains(mousePosition.getX(), mousePosition.getY()))
+		{
+			StringBuilder sb = new StringBuilder();
+			sb.append("Weight: ").append(client.getWeight()).append(" kg</br>");
+
+			if (plugin.isReplaceOrbText())
 			{
-				return null;
+				sb.append("Run Energy: ").append(client.getEnergy()).append("%");
+			}
+			else
+			{
+				sb.append("Run Time Remaining: ").append(plugin.getEstimatedRunTimeRemaining(false));
 			}
 
-			final Rectangle bounds = runOrb.getBounds();
-
-			if (bounds.getX() <= 0)
+			int secondsUntil100 = plugin.getEstimatedRecoverTimeRemaining();
+			if (secondsUntil100 > 0)
 			{
-				return null;
+				final int minutes = (int) Math.floor(secondsUntil100 / 60.0);
+				final int seconds = (int) Math.floor(secondsUntil100 - (minutes * 60.0));
+
+				sb.append("</br>").append("100% Energy In: ").append(minutes).append(':').append(StringUtils.leftPad(Integer.toString(seconds), 2, "0"));
 			}
 
-			final Point mousePosition = client.getMouseCanvasPosition();
-
-			if (bounds.contains(mousePosition.getX(), mousePosition.getY()))
-			{
-				StringBuilder sb = new StringBuilder();
-				sb.append("Weight: ").append(client.getWeight()).append(" kg</br>");
-
-				if (plugin.isReplaceOrbText())
-				{
-					sb.append("Run Energy: ").append(client.getEnergy()).append("%");
-				}
-				else
-				{
-					sb.append("Run Time Remaining: ").append(plugin.getEstimatedRunTimeRemaining(false));
-				}
-
-				int secondsUntil100 = plugin.getEstimatedRecoverTimeRemaining();
-				if (secondsUntil100 > 0)
-				{
-					final int minutes = (int) Math.floor(secondsUntil100 / 60.0);
-					final int seconds = (int) Math.floor(secondsUntil100 - (minutes * 60.0));
-
-					sb.append("</br>").append("100% Energy In: ").append(minutes).append(':').append(StringUtils.leftPad(Integer.toString(seconds), 2, "0"));
-				}
-
-				tooltipManager.add(new Tooltip(sb.toString()));
-			}
+			tooltipManager.add(new Tooltip(sb.toString()));
 		}
 
 		if (plugin.isShowRun())


### PR DESCRIPTION
Owain broke the overlay on the run energy orb by adding an extra if to the logic where it wasn't really needed so that it only ended up showing the overlay when the `run time left` option was enabled. This fixes it back to how it was originally where it always shows the overlay whenever you mouse over the run energy orb (how it was with the runenergy plugin).

Tried to make indentation look like the rest, but if it's wrong let me know and I'll try to fix it (or you can fix it if you want since I allow edits from maintainers). I've tried several things to remove the new line at the EOF that's being created but for some reason github is being dumb and not removing it..