### PR TITLE
cache: Cast ByteBuffer to Buffer to avoid compilation error with jdk 1.8u211

### DIFF
--- a/cache/src/main/java/net/runelite/cache/io/OutputStream.java
+++ b/cache/src/main/java/net/runelite/cache/io/OutputStream.java
@@ -27,6 +27,7 @@ package net.runelite.cache.io;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 public final class OutputStream extends java.io.OutputStream
@@ -56,7 +57,7 @@ public final class OutputStream extends java.io.OutputStream
 			int newCapacity = buffer.capacity() * 2;
 
 			ByteBuffer old = buffer;
-			old.flip();
+			((Buffer) old).flip();
 
 			buffer = ByteBuffer.allocate(newCapacity);
 
@@ -196,7 +197,7 @@ public final class OutputStream extends java.io.OutputStream
 
 	public byte[] flip()
 	{
-		buffer.flip();
+		((Buffer) buffer).flip();
 		byte[] b = new byte[buffer.limit()];
 		buffer.get(b);
 		return b;


### PR DESCRIPTION
Fixes a maven compilation error when using Oracles jdk 1.8u211/1.8u212.

`[ERROR] Failed to execute goal net.runelite:script-assembler-plugin:1.5.29-SNAPSHOT:assemble (assemble) on project client: Execution assemble of goal net.runelite:script-assembler-plugin:1.5.29-SNAPSHOT:assemble failed: An API incompatibility was encountered while executing net.runelite:script-assembler-plugin:1.5.29-SNAPSHOT:assemble: java.lang.NoSuchMethodError: java.nio.ByteBuffer.flip()Ljava/nio/ByteBuffer;`