### PR TITLE
npcindicators: add Interacting functionality

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/MemorizedNpc.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/MemorizedNpc.java
@@ -34,33 +34,22 @@ import lombok.Setter;
 import net.runelite.api.NPC;
 import net.runelite.api.NPCDefinition;
 import net.runelite.api.coords.WorldPoint;
-
+@Getter(AccessLevel.PACKAGE)
 class MemorizedNpc
 {
-	@Getter(AccessLevel.PACKAGE)
 	private int npcIndex;
-
-	@Getter(AccessLevel.PACKAGE)
 	private Set<String> npcNames;
-
-	@Getter(AccessLevel.PACKAGE)
 	private int npcSize;
-
 	/**
 	 * The time the npc died at, in game ticks, relative to the tick counter
 	 */
-	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private int diedOnTick;
-
 	/**
 	 * The time it takes for the npc to respawn, in game ticks
 	 */
-	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private int respawnTime;
-
-	@Getter(AccessLevel.PACKAGE)
 	@Setter(AccessLevel.PACKAGE)
 	private List<WorldPoint> possibleRespawnLocations;
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -66,10 +66,10 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 2,
-			keyName = "interactingColor",
-			name = "Interacting Color",
-			description = "Color of the NPC highlight when interacting with local player"
+		position = 2,
+		keyName = "interactingColor",
+		name = "Interacting Color",
+		description = "Color of the NPC highlight when interacting with local player"
 	)
 	default Color getInteractingColor()
 	{
@@ -88,10 +88,10 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-			position = 4,
-			keyName = "drawInteracting",
-			name = "Draw names above NPC indicating who the NPC is aggro'd to",
-			description = "Configures whether or not NPC names should be drawn above the NPC that indicate aggro target"
+		position = 4,
+		keyName = "drawInteracting",
+		name = "Draw names above NPC indicating who the NPC is aggro'd to",
+		description = "Configures whether or not NPC names should be drawn above the NPC that indicate aggro target"
 	)
 	default boolean drawInteracting()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -91,7 +91,7 @@ public interface NpcIndicatorsConfig extends Config
 		position = 4,
 		keyName = "drawInteracting",
 		name = "Draw target name above NPC",
-		description = "Configures whether or not NPC names should be drawn above the NPC that indicate aggro target"
+		description = "Configures whether the name of the NPC's target is drawn above it's head"
 	)
 	default boolean drawInteracting()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -69,7 +69,7 @@ public interface NpcIndicatorsConfig extends Config
 		position = 2,
 		keyName = "interactingColor",
 		name = "Interacting Color",
-		description = "Color of the NPC highlight when interacting with local player"
+		description = "Color of the NPC highlight when targeting local player"
 	)
 	default Color getInteractingColor()
 	{
@@ -90,7 +90,7 @@ public interface NpcIndicatorsConfig extends Config
 	@ConfigItem(
 		position = 4,
 		keyName = "drawInteracting",
-		name = "Draw names above NPC indicating who the NPC is aggro'd to",
+		name = "Draw target name above NPC",
 		description = "Configures whether or not NPC names should be drawn above the NPC that indicate aggro target"
 	)
 	default boolean drawInteracting()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsConfig.java
@@ -66,6 +66,17 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
+			position = 2,
+			keyName = "interactingColor",
+			name = "Interacting Color",
+			description = "Color of the NPC highlight when interacting with local player"
+	)
+	default Color getInteractingColor()
+	{
+		return Color.RED;
+	}
+
+	@ConfigItem(
 		position = 3,
 		keyName = "drawNames",
 		name = "Draw names above NPC",
@@ -77,7 +88,18 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+			position = 4,
+			keyName = "drawInteracting",
+			name = "Draw names above NPC indicating who the NPC is aggro'd to",
+			description = "Configures whether or not NPC names should be drawn above the NPC that indicate aggro target"
+	)
+	default boolean drawInteracting()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 5,
 		keyName = "drawMinimapNames",
 		name = "Draw names on minimap",
 		description = "Configures whether or not NPC names should be drawn on the minimap"
@@ -88,7 +110,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 6,
 		keyName = "highlightMenuNames",
 		name = "Highlight menu names",
 		description = "Highlight NPC names in right click menu"
@@ -99,7 +121,7 @@ public interface NpcIndicatorsConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 7,
 		keyName = "showRespawnTimer",
 		name = "Show respawn timer",
 		description = "Show respawn timer of tagged NPCs")

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -75,9 +75,9 @@ import net.runelite.client.util.Text;
 import net.runelite.client.util.WildcardMatcher;
 
 @PluginDescriptor(
-		name = "NPC Indicators",
-		description = "Highlight NPCs on-screen and/or on the minimap",
-		tags = {"highlight", "minimap", "npcs", "overlay", "respawn", "tags"}
+	name = "NPC Indicators",
+	description = "Highlight NPCs on-screen and/or on the minimap",
+	tags = {"highlight", "minimap", "npcs", "overlay", "respawn", "tags"}
 )
 @Slf4j
 @Singleton
@@ -90,7 +90,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final String UNTAG = "Untag";
 
 	private static final Set<MenuAction> NPC_MENU_ACTIONS = ImmutableSet.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
-	MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
+		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
 
 	@Inject
 	private Client client;
@@ -261,7 +261,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private void onGameStateChanged(GameStateChanged event)
 	{
 		if (event.getGameState() == GameState.LOGIN_SCREEN ||
-				event.getGameState() == GameState.HOPPING)
+			event.getGameState() == GameState.HOPPING)
 		{
 			highlightedNpcs.clear();
 			deadNpcsToDisplay.clear();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcIndicatorsPlugin.java
@@ -75,9 +75,9 @@ import net.runelite.client.util.Text;
 import net.runelite.client.util.WildcardMatcher;
 
 @PluginDescriptor(
-	name = "NPC Indicators",
-	description = "Highlight NPCs on-screen and/or on the minimap",
-	tags = {"highlight", "minimap", "npcs", "overlay", "respawn", "tags"}
+		name = "NPC Indicators",
+		description = "Highlight NPCs on-screen and/or on the minimap",
+		tags = {"highlight", "minimap", "npcs", "overlay", "respawn", "tags"}
 )
 @Slf4j
 @Singleton
@@ -90,7 +90,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private static final String UNTAG = "Untag";
 
 	private static final Set<MenuAction> NPC_MENU_ACTIONS = ImmutableSet.of(MenuAction.NPC_FIRST_OPTION, MenuAction.NPC_SECOND_OPTION,
-		MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
+	MenuAction.NPC_THIRD_OPTION, MenuAction.NPC_FOURTH_OPTION, MenuAction.NPC_FIFTH_OPTION);
 
 	@Inject
 	private Client client;
@@ -192,7 +192,11 @@ public class NpcIndicatorsPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private Color getHighlightColor;
 	@Getter(AccessLevel.PACKAGE)
+	private Color getInteractingColor;
+	@Getter(AccessLevel.PACKAGE)
 	private boolean drawNames;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean drawInteracting;
 	@Getter(AccessLevel.PACKAGE)
 	private boolean drawMinimapNames;
 	@Getter(AccessLevel.PACKAGE)
@@ -257,7 +261,7 @@ public class NpcIndicatorsPlugin extends Plugin
 	private void onGameStateChanged(GameStateChanged event)
 	{
 		if (event.getGameState() == GameState.LOGIN_SCREEN ||
-			event.getGameState() == GameState.HOPPING)
+				event.getGameState() == GameState.HOPPING)
 		{
 			highlightedNpcs.clear();
 			deadNpcsToDisplay.clear();
@@ -654,7 +658,9 @@ public class NpcIndicatorsPlugin extends Plugin
 		this.renderStyle = config.renderStyle();
 		this.getNpcToHighlight = config.getNpcToHighlight();
 		this.getHighlightColor = config.getHighlightColor();
+		this.getInteractingColor = config.getInteractingColor();
 		this.drawNames = config.drawNames();
+		this.drawInteracting = config.drawInteracting();
 		this.drawMinimapNames = config.drawMinimapNames();
 		this.highlightMenuNames = config.highlightMenuNames();
 		this.showRespawnTimer = config.showRespawnTimer();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcMinimapOverlay.java
@@ -63,7 +63,8 @@ public class NpcMinimapOverlay extends Overlay
 
 	private void renderNpcOverlay(Graphics2D graphics, NPC actor, String name, Color color)
 	{
-		Point minimapLocation = actor.getMinimapLocation();
+		final Point minimapLocation = actor.getMinimapLocation();
+
 		if (minimapLocation != null)
 		{
 			OverlayUtil.renderMinimapLocation(graphics, minimapLocation, color.darker());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -147,8 +147,12 @@ public class NpcSceneOverlay extends Overlay
 		}
 	}
 
-	private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
+	public void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
 	{
+		if (actor.getInteracting() == client.getLocalPlayer())
+		{
+			color = plugin.getGetInteractingColor();
+		}
 		switch (plugin.getRenderStyle())
 		{
 			case SOUTH_WEST_TILE:
@@ -206,6 +210,20 @@ public class NpcSceneOverlay extends Overlay
 			if (textLocation != null)
 			{
 				OverlayUtil.renderTextLocation(graphics, textLocation, npcName, color);
+			}
+		}
+
+		if (plugin.isDrawInteracting() && actor.getInteracting() != null)
+		{
+			int drawHeight = plugin.isDrawNames() ? 80 : 40;
+
+			String targetName = Text.removeTags(actor.getInteracting().getName());
+			Point textLocation = actor.getCanvasTextLocation(graphics, targetName, actor.getLogicalHeight() + drawHeight);
+
+
+			if (textLocation != null)
+			{
+				OverlayUtil.renderTextLocation(graphics, textLocation, targetName, color);
 			}
 		}
 	}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -147,16 +147,12 @@ public class NpcSceneOverlay extends Overlay
 		}
 	}
 
-	public void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
+	private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
 	{
-		if (actor.getInteracting() == client.getLocalPlayer())
-		{
-			color = plugin.getGetInteractingColor();
-		}
 		switch (plugin.getRenderStyle())
 		{
 			case SOUTH_WEST_TILE:
-				LocalPoint lp1 = LocalPoint.fromWorld(client, actor.getWorldLocation());
+				final LocalPoint lp1 = LocalPoint.fromWorld(client, actor.getWorldLocation());
 				Polygon tilePoly1 = null;
 				if (lp1 != null)
 				{
@@ -165,38 +161,30 @@ public class NpcSceneOverlay extends Overlay
 
 				renderPoly(graphics, color, tilePoly1);
 				break;
-
 			case TILE:
 				int size = 1;
-				NPCDefinition composition = actor.getTransformedDefinition();
+				final NPCDefinition composition = actor.getTransformedDefinition();
 				if (composition != null)
 				{
 					size = composition.getSize();
 				}
-				LocalPoint lp = actor.getLocalLocation();
-				Polygon tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
-
+				final LocalPoint lp = actor.getLocalLocation();
+				final Polygon tilePoly = Perspective.getCanvasTileAreaPoly(client, lp, size);
 				renderPoly(graphics, color, tilePoly);
 				break;
-
 			case HULL:
-				Polygon objectClickbox = actor.getConvexHull();
-
+				final Polygon objectClickbox = actor.getConvexHull();
 				renderPoly(graphics, color, objectClickbox);
 				break;
-
 			case THIN_OUTLINE:
 				modelOutliner.drawOutline(actor, 1, color);
 				break;
-
 			case OUTLINE:
 				modelOutliner.drawOutline(actor, 2, color);
 				break;
-
 			case THIN_GLOW:
 				modelOutliner.drawOutline(actor, 4, color, TRANSPARENT);
 				break;
-
 			case GLOW:
 				modelOutliner.drawOutline(actor, 8, color, TRANSPARENT);
 				break;
@@ -204,8 +192,8 @@ public class NpcSceneOverlay extends Overlay
 
 		if (plugin.isDrawNames() && actor.getName() != null)
 		{
-			String npcName = Text.removeTags(actor.getName());
-			Point textLocation = actor.getCanvasTextLocation(graphics, npcName, actor.getLogicalHeight() + 40);
+			final String npcName = Text.removeTags(actor.getName());
+			final Point textLocation = actor.getCanvasTextLocation(graphics, npcName, actor.getLogicalHeight() + 40);
 
 			if (textLocation != null)
 			{
@@ -215,11 +203,14 @@ public class NpcSceneOverlay extends Overlay
 
 		if (plugin.isDrawInteracting() && actor.getInteracting() != null)
 		{
-			int drawHeight = plugin.isDrawNames() ? 80 : 40;
+			if (actor.getInteracting() == client.getLocalPlayer())
+			{
+				color = plugin.getGetInteractingColor();
+			}
 
-			String targetName = Text.removeTags(actor.getInteracting().getName());
-			Point textLocation = actor.getCanvasTextLocation(graphics, targetName, actor.getLogicalHeight() + drawHeight);
-
+			final int drawHeight = plugin.isDrawNames() ? 80 : 40;
+			final String targetName = Text.removeTags(actor.getInteracting().getName());
+			final Point textLocation = actor.getCanvasTextLocation(graphics, targetName, actor.getLogicalHeight() + drawHeight);
 
 			if (textLocation != null)
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/npchighlight/NpcSceneOverlay.java
@@ -149,6 +149,12 @@ public class NpcSceneOverlay extends Overlay
 
 	private void renderNpcOverlay(Graphics2D graphics, NPC actor, Color color)
 	{
+		if (plugin.isDrawInteracting() && actor.getInteracting() != null
+			&& actor.getInteracting() == client.getLocalPlayer())
+		{
+			color = plugin.getGetInteractingColor();
+		}
+
 		switch (plugin.getRenderStyle())
 		{
 			case SOUTH_WEST_TILE:
@@ -203,11 +209,6 @@ public class NpcSceneOverlay extends Overlay
 
 		if (plugin.isDrawInteracting() && actor.getInteracting() != null)
 		{
-			if (actor.getInteracting() == client.getLocalPlayer())
-			{
-				color = plugin.getGetInteractingColor();
-			}
-
 			final int drawHeight = plugin.isDrawNames() ? 80 : 40;
 			final String targetName = Text.removeTags(actor.getInteracting().getName());
 			final Point textLocation = actor.getCanvasTextLocation(graphics, targetName, actor.getLogicalHeight() + drawHeight);


### PR DESCRIPTION
Adds 2 new functions to NPC Indicators involving Interacting of NPCs.
Have the name of the currently aggro'd Actor of a marked npc displayed above its head, if name config is on the position of the target name will adjust accordingly:
https://i.imgur.com/1Ml7RE5.gifv
https://i.imgur.com/qVRly3e.gifv
Have the colour of the NPC Highlight change to the colour in config if the marked NPC is currently targeting you:
https://i.imgur.com/EKrynnl.gifv