### PR TITLE
private-server: enforce osrs key if rs!=RSPS

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/privateserver/PrivateServerPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/privateserver/PrivateServerPlugin.java
@@ -75,6 +75,10 @@ public class PrivateServerPlugin extends Plugin
 			updateConfig();
 			addSubscriptions();
 		}
+		else
+		{
+			client.setModulus(new BigInteger("83ff79a3e258b99ead1a70e1049883e78e513c4cdec538d8da9483879a9f81689c0c7d146d7b82b52d05cf26132b1cda5930eeef894e4ccf3d41eebc3aabe54598c4ca48eb5a31d736bfeea17875a35558b9e3fcd4aebe2a9cc970312a477771b36e173dc2ece6001ab895c553e2770de40073ea278026f36961c94428d8d7db", 16));
+		}
 	}
 
 	@Override
@@ -110,6 +114,8 @@ public class PrivateServerPlugin extends Plugin
 	private void updateConfig()
 	{
 		if (!config.modulus().equals(""))
-		client.setModulus(new BigInteger(config.modulus(), 16));
+		{
+			client.setModulus(new BigInteger(config.modulus(), 16));
+		}
 	}
 }


### PR DESCRIPTION
rsa mismatches were still possible even when not using --rs=RSPS.