### PR TITLE
screenshot: use playerdeath events

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/events/PlayerDeath.java
+++ b/runelite-api/src/main/java/net/runelite/api/events/PlayerDeath.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019, HSJ <https://github.com/HSJ-OSRS>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.events;
+
+import lombok.Value;
+import net.runelite.api.Player;
+
+/**
+ * An event when a player dies.
+ */
+@Value
+public class PlayerDeath implements Event
+{
+	private final Player player;
+}

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSActorMixin.java
@@ -38,6 +38,7 @@ import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.HitsplatApplied;
 import net.runelite.api.events.LocalPlayerDeath;
+import net.runelite.api.events.PlayerDeath;
 import net.runelite.api.events.SpotAnimationChanged;
 import net.runelite.api.events.InteractingChanged;
 import net.runelite.api.events.OverheadTextChanged;
@@ -253,6 +254,11 @@ public abstract class RSActorMixin implements RSActor
 
 				LocalPlayerDeath event = LocalPlayerDeath.INSTANCE;
 				client.getCallbacks().post(LocalPlayerDeath.class, event);
+			}
+			else if (this != client.getLocalPlayer() && this instanceof Player)
+			{
+				final PlayerDeath event = new PlayerDeath((Player) this);
+				client.getCallbacks().post(PlayerDeath.class, event);
 			}
 			else if (this instanceof RSNPC)
 			{


### PR DESCRIPTION
using the LocalPlayerDeath and PlayerDeath events captures the screenshot with the killing hit splat still showing rather than just the player in the death animation. 