### PR TITLE
gradle: partially revert #1166

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ allprojects {
         gitDirty = localGitDirty
 
         rootPath = rootDir.toString().replace('\\', '/')
-        injectedClassesPath = rootPath + "/injected-client/build/libs/injected-client-" + version + ".jar"
+        injectedClassesPath = rootPath + "/injector-plugin/out/injected-client/"
     }
 }
 

--- a/injected-client/src/main/java/Placeholder.java
+++ b/injected-client/src/main/java/Placeholder.java
@@ -22,26 +22,13 @@
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
-description = 'Injected Client'
 
-compileJava {
-    dependsOn ':injector-plugin:assemble'
+/**
+ * @author ThatGamerBlue
+ *
+ * This file exists to force gradle to execute the compileJava task
+ * so we can hijack it and run the injector-plugin
+ */
+public class Placeholder
+{
 }
-
-compileJava.outputs.upToDateWhen { false }
-
-compileJava.doLast() {
-    copy {
-        File f = file("build/classes/java/main")
-        f.deleteDir()
-        f.mkdirs()
-        from ("${injectedClassesPath}")
-        into ("build/classes/java/main")
-    }
-}
-
-classes.doLast() {
-    File f = file("build/classes/java/main/Placeholder.class")
-    f.delete()
-}
-

--- a/injector-plugin/src/main/java/net/runelite/injector/Injector.java
+++ b/injector-plugin/src/main/java/net/runelite/injector/Injector.java
@@ -26,6 +26,9 @@ package net.runelite.injector;
 
 import java.io.File;
 import java.io.IOException;
+
+import com.google.common.io.Files;
+import net.runelite.asm.ClassFile;
 import net.runelite.asm.ClassGroup;
 import net.runelite.deob.util.JarUtil;
 
@@ -69,7 +72,13 @@ public class Injector
 
 	private void save(File out) throws IOException
 	{
-		JarUtil.saveJar(vanilla, out);
+		out.mkdirs();
+		for (ClassFile cf : vanilla.getClasses())
+		{
+			File f = new File(out, cf.getClassName() + ".class");
+			byte[] data = JarUtil.writeClass(vanilla, cf);
+			Files.write(data, f);
+		}
 	}
 
 

--- a/runelite-client/build.gradle
+++ b/runelite-client/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     runtime group: 'org.jogamp.gluegen', name: 'gluegen-rt', version: '2.3.2', classifier: 'natives-linux-amd64'
     runtime group: 'org.jogamp.gluegen', name: 'gluegen-rt', version: '2.3.2', classifier: 'natives-linux-i586'
     runtime project(':runescape-api')
-    runtimeOnly files("${injectedClassesPath}")
+    runtime project(':injected-client')
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.26'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-library', version: '2.1'
@@ -92,8 +92,6 @@ jar {
 }
 
 shadowJar {
-    dependsOn ':injected-client:injector'
-
     archiveClassifier.set("shaded")
 
     exclude("net/runelite/injector/**")


### PR DESCRIPTION
This fixes the `upload` task so when deploying `injected-client` it will deploy the build result instead of an empty jar file.