### PR TITLE
raidsthieving: ignore room rotation

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raidsthieving/BatSolver/ThievingRoomType.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raidsthieving/BatSolver/ThievingRoomType.java
@@ -27,7 +27,7 @@ package net.runelite.client.plugins.raidsthieving.BatSolver;
 // There are three distinct Thieving rooms, distinguished by the position of the entrance relative to the exit
 // e.g. If you enter the room and must turn left to get to the exit and trough, this is a LEFT_TURN
 
-import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.Point;
 
 public enum ThievingRoomType
 {
@@ -44,7 +44,7 @@ public enum ThievingRoomType
 		this.y = y;
 	}
 
-	public static ThievingRoomType identifyByInstancePoint(WorldPoint point)
+	public static ThievingRoomType identifyByInstancePoint(Point point)
 	{
 		for (ThievingRoomType type : ThievingRoomType.values())
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/raidsthieving/ThievingChest.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raidsthieving/ThievingChest.java
@@ -68,13 +68,13 @@ public class ThievingChest
 	 * @param worldPoint The world location of the gameobject that corresponds with this trap.
 	 * @param instancePoint The world location accounting for instances of the gameobject that corresponds with this trap.
 	 */
-	ThievingChest(final WorldPoint worldPoint, final WorldPoint instancePoint)
+	ThievingChest(final WorldPoint worldPoint, final Point instancePoint)
 	{
 		this.everOpened = false;
 		this.poison = false;
 		this.empty = false;
 		this.worldPoint = worldPoint;
-		this.instancePoint = new Point(instancePoint.getX(), instancePoint.getY());
+		this.instancePoint = instancePoint;
 		this.chestId = -1;
 	}
 


### PR DESCRIPTION
re add and use the original world point conversion methods to account for thieving rooms rotation currently only one rotation of each type of thieving room works unluckily the room i tested for the last pr was one of the working rotations so this slipped by.