### PR TITLE
menuentryswapper: Fix Swaps for Coal Bag

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1576,6 +1576,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry("Teleport", "Mounted Hunter Cape");
 		menuManager.removePriorityEntry("Teleport", "Mounted Fishing Cape");
 		menuManager.removePriorityEntry("Spellbook", "Mounted Magic Cape");
+		menuManager.removePriorityEntry("Empty", "Coal bag");
 		menuManager.removePriorityEntry("Perks", "Mounted Max Cape");
 		menuManager.removePriorityEntry("Private");
 		menuManager.removePriorityEntry("Pick-lots");

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1322,8 +1322,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (this.swapCoalBag)
 		{
-			menuManager.addPriorityEntry("Empty", "Coal bag").setPriority(90);
-			menuManager.addPriorityEntry("Fill", "Coal bag").setPriority(100);
+			menuManager.addPriorityEntry("Fill", "Coal bag");
+			menuManager.addPriorityEntry(new BankComparableEntry("Empty", "Coal bag"));
 		}
 
 		if (this.swapBones)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/menuentryswapper/MenuEntrySwapperPlugin.java
@@ -1322,7 +1322,8 @@ public class MenuEntrySwapperPlugin extends Plugin
 
 		if (this.swapCoalBag)
 		{
-			menuManager.addPriorityEntry("Empty", "Coal bag");
+			menuManager.addPriorityEntry("Empty", "Coal bag").setPriority(90);
+			menuManager.addPriorityEntry("Fill", "Coal bag").setPriority(100);
 		}
 
 		if (this.swapBones)
@@ -1577,6 +1578,7 @@ public class MenuEntrySwapperPlugin extends Plugin
 		menuManager.removePriorityEntry("Teleport", "Mounted Fishing Cape");
 		menuManager.removePriorityEntry("Spellbook", "Mounted Magic Cape");
 		menuManager.removePriorityEntry("Empty", "Coal bag");
+		menuManager.removePriorityEntry("Fill", "Coal bag");
 		menuManager.removePriorityEntry("Perks", "Mounted Max Cape");
 		menuManager.removePriorityEntry("Private");
 		menuManager.removePriorityEntry("Pick-lots");


### PR DESCRIPTION
Swaps were not being cleared correctly, needed an extra removePriorityEntry to make it work as intended.