### PR TITLE
multilines: fix bug that caused lag/fps spikes after leaving client open and hopping lots of worlds

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsConfig.java
@@ -74,7 +74,7 @@ public interface MultiIndicatorsConfig extends Config
 	)
 	default boolean showWildernessLevelLines()
 	{
-		return true;
+		return false;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsMinimapOverlay.java
@@ -38,6 +38,8 @@ import net.runelite.api.Client;
 import net.runelite.api.Perspective;
 import net.runelite.api.Point;
 import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -102,6 +104,18 @@ public class MultiIndicatorsMinimapOverlay extends Overlay
 		{
 			return null;
 		}
+
+		Widget w;
+		if (client.getWidget(WidgetInfo.FIXED_VIEWPORT_MINIMAP_DRAW_AREA) != null)
+		{
+			w = client.getWidget(WidgetInfo.FIXED_VIEWPORT_MINIMAP_DRAW_AREA);
+		}
+		else
+		{
+			w = client.getWidget(WidgetInfo.RESIZABLE_MINIMAP_STONES_DRAW_AREA);
+		}
+		Rectangle minimapClip = w.getBounds();
+		graphics.setClip(minimapClip);
 
 		GeneralPath multicombatPath = plugin.getMulticombatPathToDisplay()[client.getPlane()];
 		GeneralPath pvpPath = plugin.getPvpPathToDisplay()[client.getPlane()];

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
@@ -183,15 +183,12 @@ public class MultiIndicatorsPlugin extends Plugin
 	// sometimes the lines get offset (seems to happen when there is a delay
 	// due to map reloading when walking/running "Loading - please wait")
 	// resetting the lines generation logic fixes this
-	@Schedule(
-		period = 1800,
-		unit = ChronoUnit.MILLIS
-	)
+
 	public void update()
 	{
 		if (client.getGameState() == GameState.LOGGED_IN)
 		{
-			findLinesInScene();
+			clientThread.invokeLater(this::findLinesInScene);
 		}
 
 	}
@@ -293,10 +290,7 @@ public class MultiIndicatorsPlugin extends Plugin
 		// Generate lines for multicombat zones
 		if (this.multicombatZoneVisibility == ZoneVisibility.HIDE)
 		{
-			for (int i = 0; i < multicombatPathToDisplay.length; i++)
-			{
-				multicombatPathToDisplay[i] = null;
-			}
+			Arrays.fill(multicombatPathToDisplay, null);
 		}
 		else
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/multiindicators/MultiIndicatorsPlugin.java
@@ -29,7 +29,6 @@ import com.google.inject.Provides;
 import java.awt.Color;
 import java.awt.Rectangle;
 import java.awt.geom.GeneralPath;
-import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -55,7 +54,6 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.plugins.PluginType;
-import net.runelite.client.task.Schedule;
 import net.runelite.client.ui.overlay.OverlayManager;
 
 @PluginDescriptor(


### PR DESCRIPTION
removes the scheduled method that updated the lines every 1.8s and updates them on clientthread now. seems to have fixed the lag/fps spike that would happen after leaving client open for long time/hopping worlds.

adds clipping for lines rendered on minimap

need to eventually refactor multilines plugin and maybe make it use world locations

Signed-off-by: PKLite <stonewall@pklite.xyz>