### PR TITLE
gradle: update env vars to use underscores

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,8 +79,8 @@ subprojects {
     uploadArchives {
         repositories {
             mavenDeployer {
-                repository(url: System.getenv("NEXUS-URL")) {
-                    authentication(userName: System.getenv("NEXUS-USER"), password: System.getenv("NEXUS-PASSWORD"))
+                repository(url: System.getenv("NEXUS_URL")) {
+                    authentication(userName: System.getenv("NEXUS_USER"), password: System.getenv("NEXUS_PASSWORD"))
                 }
             }
         }


### PR DESCRIPTION
Provides better compatibility with /bin/sh, /bin/bash and the likes, which don't accept env vars with dashes in the name.