### PR TITLE
injector: fix it getting confused over two menuAction methods

### DIFF
--- a/runescape-client/src/main/java/Messages.java
+++ b/runescape-client/src/main/java/Messages.java
@@ -800,7 +800,7 @@ public class Messages {
 
 											if (var2 != 1007) {
 												if (var2 == 1011 || var2 == 1008 || var2 == 1010 || var2 == 1009 || var2 == 1012) {
-													BoundaryObject.worldMap.menuAction(var2, var3, new Coord(var0), new Coord(var1));
+													BoundaryObject.worldMap.menuActionTwoElectricBoogaloo(var2, var3, new Coord(var0), new Coord(var1));
 												}
 												break label926;
 											}

--- a/runescape-client/src/main/java/WorldMap.java
+++ b/runescape-client/src/main/java/WorldMap.java
@@ -1372,8 +1372,8 @@ public class WorldMap {
 		signature = "(IILhv;Lhv;B)V",
 		garbageValue = "8"
 	)
-	@Export("menuAction")
-	public void menuAction(int var1, int var2, Coord var3, Coord var4) {
+	@Export("menuActionTwoElectricBoogaloo")
+	public void menuActionTwoElectricBoogaloo(int var1, int var2, Coord var3, Coord var4) {
 		ScriptEvent var5 = new ScriptEvent();
 		WorldMapEvent var6 = new WorldMapEvent(var2, var3, var4);
 		var5.setArgs(new Object[]{var6});


### PR DESCRIPTION
Fixes the error `net.runelite.injector.InjectionException: Mixin method static net/runelite/mixins/RSClientMixin.rs$menuAction(IIIILjava/lang/String;Ljava/lang/String;II)V should be non-static` that seems to crop up randomly.