### PR TITLE
grounditems: lighten default highlight color

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -74,7 +74,7 @@ public interface GroundItemsConfig extends Config
 	@Alpha
 	default Color highlightedColor()
 	{
-		return Color.decode("#AA00FF");
+		return Color.decode("#C46AFF");
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
Seems a bit dark in most environments, making text illegible in some circumstances. I also happen to like the pastel colors we've been moving to.

![image](https://user-images.githubusercontent.com/2943260/62839649-a7cfc200-bc5a-11e9-825b-3e330a9a6055.png)
