### PR TITLE
theatre: remove unnecessary reset.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/theatre/rooms/SotetsegHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/theatre/rooms/SotetsegHandler.java
@@ -76,7 +76,6 @@ public class SotetsegHandler extends RoomHandler
 	private void reset()
 	{
 		npc = null;
-		soteyProjectiles.clear();
 		redTiles.clear();
 		redOverworld.clear();
 		blackOverworld.clear();


### PR DESCRIPTION
The soteyProjectiles.clear() is not required and clears the Projectiles before they are rendered.