### PR TITLE
Worldhopper: pvp hop restriction

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperConfig.java
@@ -115,10 +115,21 @@ public interface WorldHopperConfig extends Config
 	}
 
 	@ConfigItem(
+		keyName = "removePVPWorld",
+		name = "remove Hop-to menu option (PVP)",
+		description = "removes Hop-to menu option for pvp worlds",
+		position = 7
+	)
+	default boolean removePVPWorld()
+	{
+		return false;
+	}
+
+	@ConfigItem(
 		keyName = "subscriptionFilter",
 		name = "Show subscription types",
 		description = "Only show free worlds, member worlds, or both types of worlds in sidebar",
-		position = 7
+		position = 8
 	)
 	default SubscriptionFilterMode subscriptionFilter()
 	{
@@ -129,7 +140,7 @@ public interface WorldHopperConfig extends Config
 		keyName = "displayPing",
 		name = "Display current ping",
 		description = "Displays ping to current game world",
-		position = 7
+		position = 9
 	)
 	default boolean displayPing()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -416,8 +416,7 @@ public class WorldHopperPlugin extends Plugin
 
 			World currentWorld = worldResult.findWorld(client.getWorld());
 			World targetWorld = worldResult.findWorld(player.getWorld());
-			if (targetWorld == null || currentWorld == null
-				|| (!currentWorld.getTypes().contains(WorldType.PVP) && targetWorld.getTypes().contains(WorldType.PVP)))
+			if (targetWorld == null || currentWorld == null)
 			{
 				// Disable Hop-to a PVP world from a regular world
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -167,6 +167,8 @@ public class WorldHopperPlugin extends Plugin
 	private boolean ping;
 	private boolean showWorldHopMessage;
 	private SubscriptionFilterMode subscriptionFilter;
+	private boolean menuOption;
+	private boolean removePVPWorld;
 	@Getter(AccessLevel.PACKAGE)
 	private boolean displayPing;
 
@@ -230,7 +232,7 @@ public class WorldHopperPlugin extends Plugin
 
 		overlayManager.add(worldHopperOverlay);
 
-		panel.setFilterMode(config.subscriptionFilter());
+		panel.setFilterMode(this.subscriptionFilter);
 
 		// The plugin has its own executor for pings, as it blocks for a long time
 		hopperExecutorService = new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor());
@@ -380,7 +382,7 @@ public class WorldHopperPlugin extends Plugin
 
 	private void onMenuEntryAdded(MenuEntryAdded event)
 	{
-		if (!config.menuOption())
+		if (!this.menuOption)
 		{
 			return;
 		}
@@ -416,10 +418,13 @@ public class WorldHopperPlugin extends Plugin
 
 			World currentWorld = worldResult.findWorld(client.getWorld());
 			World targetWorld = worldResult.findWorld(player.getWorld());
-			if (targetWorld == null || currentWorld == null)
+			if ((targetWorld == null || currentWorld == null)
+				|| (!this.removePVPWorld && !currentWorld.getTypes().contains(WorldType.PVP) && targetWorld.getTypes().contains(WorldType.PVP)))
 			{
+				// Disable Hop-to a PVP world from a regular world
 				return;
 			}
+
 
 			final MenuEntry hopTo = new MenuEntry();
 			hopTo.setOption(HOP_TO);
@@ -835,6 +840,8 @@ public class WorldHopperPlugin extends Plugin
 		this.showWorldHopMessage = config.showWorldHopMessage();
 		this.subscriptionFilter = config.subscriptionFilter();
 		this.displayPing = config.displayPing();
+		this.menuOption = config.menuOption();
+		this.removePVPWorld = config.removePVPWorld();
 	}
 
 	/**
@@ -842,7 +849,7 @@ public class WorldHopperPlugin extends Plugin
 	 */
 	private void pingNextWorld()
 	{
-		if (worldResult == null || !config.showSidebar() || !config.ping())
+		if (worldResult == null || !this.showSidebar || !this.ping)
 		{
 			return;
 		}
@@ -862,7 +869,7 @@ public class WorldHopperPlugin extends Plugin
 		World world = worlds.get(currentWorld++);
 
 		// If we are displaying the ping overlay, there is a separate scheduled task for the current world
-		boolean displayPing = config.displayPing() && client.getGameState() == GameState.LOGGED_IN;
+		boolean displayPing = this.displayPing && client.getGameState() == GameState.LOGGED_IN;
 		if (displayPing && client.getWorld() == world.getId())
 		{
 			return;
@@ -879,7 +886,7 @@ public class WorldHopperPlugin extends Plugin
 	private void pingCurrentWorld()
 	{
 		// There is no reason to ping the current world if not logged in, as the overlay doesn't draw
-		if (worldResult == null || !config.displayPing() || client.getGameState() != GameState.LOGGED_IN)
+		if (worldResult == null || !this.displayPing || client.getGameState() != GameState.LOGGED_IN)
 		{
 			return;
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -418,7 +418,6 @@ public class WorldHopperPlugin extends Plugin
 			World targetWorld = worldResult.findWorld(player.getWorld());
 			if (targetWorld == null || currentWorld == null)
 			{
-				// Disable Hop-to a PVP world from a regular world
 				return;
 			}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/worldhopper/WorldHopperPlugin.java
@@ -419,7 +419,7 @@ public class WorldHopperPlugin extends Plugin
 			World currentWorld = worldResult.findWorld(client.getWorld());
 			World targetWorld = worldResult.findWorld(player.getWorld());
 			if ((targetWorld == null || currentWorld == null)
-				|| (!this.removePVPWorld && !currentWorld.getTypes().contains(WorldType.PVP) && targetWorld.getTypes().contains(WorldType.PVP)))
+				|| (this.removePVPWorld && !currentWorld.getTypes().contains(WorldType.PVP) && targetWorld.getTypes().contains(WorldType.PVP)))
 			{
 				// Disable Hop-to a PVP world from a regular world
 				return;


### PR DESCRIPTION
removes the pvp hop-to restriction from a normal world.

been requested alot by pure and main clans as its very annoying when clanning / singles pking and you cant right/left click hop-to whilst in CC or via friends list if in a non PVP world..

just to confirm, the WARNING that you're hopping to a PVP world is still active to avoid luring/scamming.