### PR TITLE
add null check guard case for chat message manager

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/chat/ChatMessageManager.java
@@ -570,6 +570,12 @@ public class ChatMessageManager
 			return;
 		}
 
+		//guard case for google MoreObjects#firstNonNull
+		if (message.getValue() == null && message.getRuneLiteFormattedMessage() == null)
+		{
+			return;
+		}
+
 		// this updates chat cycle
 		client.addChatMessage(
 			message.getType(),


### PR DESCRIPTION
Supersedes #1409 

Closes #1406 

Had to cherry-pick commits to clean up history because it's meant to be `&&`, and I'm an idiot. Sorry @Netami1