### PR TITLE
Playerscouter: add combat bracket

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
@@ -190,7 +190,7 @@ public class PlayerScouter extends Plugin
 		{
 			update(player);
 			if (player.getPlayer().getCombatLevel() < this.minimumCombat
-				&& player.getPlayer().getCombatLevel() > this.maximumCombat)
+				|| player.getPlayer().getCombatLevel() > this.maximumCombat)
 			{
 				return;
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
@@ -111,6 +111,8 @@ public class PlayerScouter extends Plugin
 	private int minimumRisk;
 	private int minimumValue;
 	private int timeout;
+	private int minimumCombat;
+	private int maximumCombat;
 	private boolean onlyWildy;
 	private boolean outputItems;
 	private boolean scoutFriends;
@@ -176,6 +178,7 @@ public class PlayerScouter extends Plugin
 
 	private void onGameTick(GameTick event)
 	{
+
 		resetBlacklist();
 
 		if (!checkWildy() || playerContainer.isEmpty())
@@ -186,7 +189,13 @@ public class PlayerScouter extends Plugin
 		playerContainer.forEach(player ->
 		{
 			update(player);
-			if (player.getRisk() > this.minimumRisk)
+			if(player.getPlayer().getCombatLevel() < this.minimumCombat
+				&& player.getPlayer().getCombatLevel() > this.maximumCombat)
+			{
+				return;
+			}
+			if ((player.getPlayer().getCombatLevel() >= this.minimumCombat
+				&& player.getPlayer().getCombatLevel() <= this.maximumCombat) && player.getRisk() > this.minimumRisk)
 			{
 				scoutPlayer(player);
 			}
@@ -259,6 +268,8 @@ public class PlayerScouter extends Plugin
 		this.outputItems = config.outputItems();
 		this.scoutClan = config.scoutClan();
 		this.scoutFriends = config.scoutFriends();
+		this.minimumCombat = config.minimumCombat();
+		this.maximumCombat = config.maximumCombat();
 	}
 
 	private void update(PlayerContainer player)

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouter.java
@@ -189,7 +189,7 @@ public class PlayerScouter extends Plugin
 		playerContainer.forEach(player ->
 		{
 			update(player);
-			if(player.getPlayer().getCombatLevel() < this.minimumCombat
+			if (player.getPlayer().getCombatLevel() < this.minimumCombat
 				&& player.getPlayer().getCombatLevel() > this.maximumCombat)
 			{
 				return;

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouterConfig.java
@@ -26,6 +26,7 @@ package net.runelite.client.plugins.playerscouter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.Range;
 
 @ConfigGroup("playerscouter")
 public interface PlayerScouterConfig extends Config
@@ -108,11 +109,41 @@ public interface PlayerScouterConfig extends Config
 		return 1000;
 	}
 
+	@Range(
+		min = 3,
+		max = 125
+	)
+	@ConfigItem(
+		keyName = "minimumCombat",
+		name = "Minimum Combat Level",
+		description = "The Minimum Combat Level you wish to scout.",
+		position = 7
+	)
+	default int minimumCombat()
+	{
+		return 3;
+	}
+
+	@Range(
+		min = 4,
+		max = 126
+	)
+	@ConfigItem(
+		keyName = "maximumCombat",
+		name = "Maximum Combat Level",
+		description = "The Maximum Combat Level you wish to scout.",
+		position = 8
+	)
+	default int maximumCombat()
+	{
+		return 3;
+	}
+
 	@ConfigItem(
 		keyName = "timeout",
 		name = "Timeout",
 		description = "Minimum amount of ticks before the player can be scouted again. (1 tick = 600ms)",
-		position = 7
+		position = 9
 	)
 	default int timeout()
 	{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouterConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerscouter/PlayerScouterConfig.java
@@ -136,7 +136,7 @@ public interface PlayerScouterConfig extends Config
 	)
 	default int maximumCombat()
 	{
-		return 3;
+		return 126;
 	}
 
 	@ConfigItem(


### PR DESCRIPTION
add a searchable combat bracket for the player scouter.

stress tested by @Crystalknoct.

in W302 GE, FPS dropped to 30, in medium populated area's and other worlds, solid 50 FPS.
