### PR TITLE
herbiboar: Fix FPS drops by removing clickbox option

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017, Tyler <https://github.com/tylerthardy>
+ * Copyright (c) 2019, Gamer1120 <https://github.com/Gamer1120>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -122,6 +123,17 @@ public interface HerbiboarConfig extends Config
 
 	@ConfigItem(
 		position = 8,
+		keyName = "showOnlyCurrentTrail",
+		name = "Show Current Trail Only",
+		description = "Only show the trail that you currently have to follow to get to the next object you have to inspect. Requires that the \"Show Trail\" option is enabled"
+	)
+	default boolean isOnlyCurrentTrailShown()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 9,
 		keyName = "colorTrail",
 		name = "Trail Color",
 		description = "Color for mushrooms, mud, seaweed, etc"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarConfig.java
@@ -46,17 +46,6 @@ public interface HerbiboarConfig extends Config
 
 	@ConfigItem(
 		position = 1,
-		keyName = "showClickboxes",
-		name = "Show Clickboxes",
-		description = "Show clickboxes on trail objects and tunnels instead of tiles"
-	)
-	default boolean showClickBoxes()
-	{
-		return false;
-	}
-
-	@ConfigItem(
-		position = 2,
 		keyName = "colorStart",
 		name = "Start Color",
 		description = "Color for rocks that start the trails"
@@ -67,7 +56,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 2,
 		keyName = "showTunnel",
 		name = "Show End Tunnels",
 		description = "Show highlights for tunnels with herbiboars"
@@ -78,7 +67,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 3,
 		keyName = "colorTunnel",
 		name = "Tunnel Color",
 		description = "Color for tunnels with herbiboars"
@@ -89,7 +78,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 5,
+		position = 4,
 		keyName = "showObject",
 		name = "Show Trail Objects",
 		description = "Show highlights for mushrooms, mud, seaweed, etc"
@@ -100,7 +89,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 6,
+		position = 5,
 		keyName = "colorGameObject",
 		name = "Trail Object Color",
 		description = "Color for mushrooms, mud, seaweed, etc"
@@ -111,7 +100,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 7,
+		position = 6,
 		keyName = "showTrail",
 		name = "Show Trail",
 		description = "Show highlights for trail prints"
@@ -122,7 +111,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 8,
+		position = 7,
 		keyName = "showOnlyCurrentTrail",
 		name = "Show Current Trail Only",
 		description = "Only show the trail that you currently have to follow to get to the next object you have to inspect. Requires that the \"Show Trail\" option is enabled"
@@ -133,7 +122,7 @@ public interface HerbiboarConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 9,
+		position = 8,
 		keyName = "colorTrail",
 		name = "Trail Color",
 		description = "Color for mushrooms, mud, seaweed, etc"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarMinimapOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarMinimapOverlay.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Kamiel
+ * Copyright (c) 2019, Gamer1120 <https://github.com/Gamer1120>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -55,7 +56,15 @@ public class HerbiboarMinimapOverlay extends Overlay
 		{
 			HerbiboarTrail currentTrail = plugin.getCurrentTrail();
 			int finishId = plugin.getFinishId();
-			Set<Integer> shownTrailIds = plugin.getShownTrails();
+			Set<Integer> shownTrailIds;
+			if (plugin.isOnlyCurrentTrailShown())
+			{
+				shownTrailIds = plugin.getCurrentTrailIds();
+			}
+			else
+			{
+				shownTrailIds = plugin.getShownTrails();
+			}
 
 			for (TileObject tileObject : plugin.getTrails().values())
 			{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -171,7 +171,8 @@ class HerbiboarOverlay extends Overlay
 		{
 			for (NPC npc : client.getNpcs())
 			{
-				if (npc.getId() == NpcID.HERBIBOAR || npc.getId() == NpcID.HERBIBOAR_7786) {
+				if (npc.getId() == NpcID.HERBIBOAR || npc.getId() == NpcID.HERBIBOAR_7786)
+				{
 					OverlayUtil.renderPolygon(graphics, npc.getConvexHull(), plugin.getGetObjectColor());
 				}
 			}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -32,13 +32,12 @@ import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.geom.Area;
 import java.util.Set;
-import lombok.Getter;
-import lombok.Setter;
 import net.runelite.api.Client;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
 import net.runelite.api.TileObject;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.client.graphics.ModelOutlineRenderer;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -47,22 +46,20 @@ import net.runelite.client.ui.overlay.OverlayUtil;
 @Singleton
 class HerbiboarOverlay extends Overlay
 {
-	@Inject
-	@Getter
+
 	private Client client;
 
-	@Getter
-	@Setter
-	private WorldPoint herbiboarLocation;
-
 	private final HerbiboarPlugin plugin;
+	private final ModelOutlineRenderer outlineRenderer;
 
 	@Inject
-	public HerbiboarOverlay(final HerbiboarPlugin plugin)
+	public HerbiboarOverlay(final HerbiboarPlugin plugin, ModelOutlineRenderer outlineRenderer, Client client)
 	{
 		setPosition(OverlayPosition.DYNAMIC);
 		setLayer(OverlayLayer.ABOVE_SCENE);
 		this.plugin = plugin;
+		this.outlineRenderer = outlineRenderer;
+		this.client = client;
 	}
 
 	@Override
@@ -173,7 +170,7 @@ class HerbiboarOverlay extends Overlay
 			{
 				if (npc.getId() == NpcID.HERBIBOAR || npc.getId() == NpcID.HERBIBOAR_7786)
 				{
-					OverlayUtil.renderPolygon(graphics, npc.getConvexHull(), plugin.getGetObjectColor());
+					outlineRenderer.drawOutline(npc, 2, plugin.getGetObjectColor());
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -118,21 +118,7 @@ class HerbiboarOverlay extends Overlay
 				TileObject object = plugin.getTrailObjects().get(trailLoc);
 				if (object != null)
 				{
-					if (plugin.isShowClickBoxes())
-					{
-						Area clickbox = object.getClickbox();
-						if (clickbox != null)
-						{
-							graphics.setColor(plugin.getGetObjectColor());
-							graphics.draw(clickbox);
-							graphics.setColor(new Color(255, 0, 255, 20));
-							graphics.fill(clickbox);
-						}
-					}
-					else
-					{
 						OverlayUtil.renderTileOverlay(graphics, object, "", plugin.getGetObjectColor());
-					}
 				}
 			}
 		}
@@ -144,22 +130,7 @@ class HerbiboarOverlay extends Overlay
 			TileObject object = plugin.getTunnels().get(finishLoc);
 			if (object != null)
 			{
-				if (plugin.isShowClickBoxes())
-				{
-					Area clickbox = object.getClickbox();
-					if (clickbox != null)
-					{
-						Color col = plugin.getGetObjectColor();
-						graphics.setColor(col);
-						graphics.draw(clickbox);
-						graphics.setColor(new Color(col.getRed(), col.getGreen(), col.getBlue(), 20));
-						graphics.fill(clickbox);
-					}
-				}
-				else
-				{
-					OverlayUtil.renderTileOverlay(graphics, object, "", plugin.getGetTunnelColor());
-				}
+				OverlayUtil.renderTileOverlay(graphics, object, "", plugin.getGetTunnelColor());
 			}
 		}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarOverlay.java
@@ -35,14 +35,9 @@ import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
-import net.runelite.api.Entity;
-import net.runelite.api.GameObject;
 import net.runelite.api.NPC;
 import net.runelite.api.NpcID;
-import net.runelite.api.Scene;
-import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
-import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayLayer;
@@ -83,7 +78,7 @@ class HerbiboarOverlay extends Overlay
 		int finishId = plugin.getFinishId();
 
 		// Draw start objects
-		if (plugin.isStartShown() && currentTrail == null && finishId == 0 && plugin.getHerbiboarLocation() == null)
+		if (plugin.isStartShown() && currentTrail == null && finishId == 0 && !plugin.isHerbiboarRendered())
 		{
 			plugin.getStarts().values().forEach((obj) ->
 				OverlayUtil.renderTileOverlay(graphics, obj, "", plugin.getGetStartColor()));
@@ -172,33 +167,12 @@ class HerbiboarOverlay extends Overlay
 		}
 
 		// Draw herbiboar
-		WorldPoint herbiboarLocation = plugin.getHerbiboarLocation();
-		if (herbiboarLocation != null)
+		if (plugin.isHerbiboarRendered())
 		{
-			LocalPoint localHerbiboarLocation = LocalPoint.fromWorld(client, herbiboarLocation);
-			final Scene scene = client.getScene();
-			final Tile[][][] tiles = scene.getTiles();
-			final Tile tile = tiles[client.getPlane()][localHerbiboarLocation.getSceneX()][localHerbiboarLocation.getSceneY()];
-			for (GameObject object : tile.getGameObjects())
+			for (NPC npc : client.getNpcs())
 			{
-				if (object != null)
-				{
-					Entity entity = object.getEntity();
-					if (entity instanceof NPC)
-					{
-						if (((NPC) entity).getId() == NpcID.HERBIBOAR || ((NPC) entity).getId() == NpcID.HERBIBOAR_7786)
-						{
-							Area clickbox = object.getClickbox();
-							if (clickbox != null)
-							{
-								Color col = plugin.getGetObjectColor();
-								graphics.setColor(col);
-								graphics.draw(clickbox);
-								graphics.setColor(new Color(col.getRed(), col.getGreen(), col.getBlue(), 20));
-								graphics.fill(clickbox);
-							}
-						}
-					}
+				if (npc.getId() == NpcID.HERBIBOAR || npc.getId() == NpcID.HERBIBOAR_7786) {
+					OverlayUtil.renderPolygon(graphics, npc.getConvexHull(), plugin.getGetObjectColor());
 				}
 			}
 		}

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -159,7 +159,7 @@ public class HerbiboarPlugin extends Plugin
 
 	@Getter
 	@Setter
-	private WorldPoint herbiboarLocation = null;
+	private boolean herbiboarRendered = false;
 
 	@Getter(AccessLevel.PACKAGE)
 	private boolean isStartShown;
@@ -357,17 +357,17 @@ public class HerbiboarPlugin extends Plugin
 		// Herbiboar spawns
 		if (npc.getId() == NpcID.HERBIBOAR_7786 && npc.getAnimation() == 7687)
 		{
-			herbiboarLocation = npc.getWorldLocation();
+			herbiboarRendered = true;
 		}
 		// Herbiboar is stunned
 		else if (npc.getId() == NpcID.HERBIBOAR && npc.getAnimation() == 7689)
 		{
-			herbiboarLocation = npc.getWorldLocation();
+			herbiboarRendered = true;
 		}
 		// Herbiboar is harvested
 		else if (npc.getId() == NpcID.HERBIBOAR_7786 && npc.getAnimation() == 7690)
 		{
-			herbiboarLocation = null;
+			herbiboarRendered = false;
 		}
 	}
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -164,8 +164,6 @@ public class HerbiboarPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private boolean isStartShown;
 	@Getter(AccessLevel.PACKAGE)
-	private boolean showClickBoxes;
-	@Getter(AccessLevel.PACKAGE)
 	private Color getStartColor;
 	@Getter(AccessLevel.PACKAGE)
 	private boolean isTunnelShown;
@@ -485,7 +483,6 @@ public class HerbiboarPlugin extends Plugin
 	private void updateConfig()
 	{
 		this.isStartShown = config.isStartShown();
-		this.showClickBoxes = config.showClickBoxes();
 		this.getStartColor = config.getStartColor();
 		this.isTunnelShown = config.isTunnelShown();
 		this.getTunnelColor = config.getTunnelColor();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/herbiboars/HerbiboarPlugin.java
@@ -38,6 +38,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.api.Client;
+import net.runelite.api.NPC;
+import net.runelite.api.NpcID;
 import static net.runelite.api.ObjectID.DRIFTWOOD_30523;
 import static net.runelite.api.ObjectID.MUSHROOM_30520;
 import static net.runelite.api.ObjectID.ROCK_30519;
@@ -47,6 +49,7 @@ import net.runelite.api.Tile;
 import net.runelite.api.TileObject;
 import net.runelite.api.Varbits;
 import net.runelite.api.coords.WorldPoint;
+import net.runelite.api.events.AnimationChanged;
 import net.runelite.api.events.ConfigChanged;
 import net.runelite.api.events.GameObjectChanged;
 import net.runelite.api.events.GameObjectDespawned;
@@ -146,6 +149,18 @@ public class HerbiboarPlugin extends Plugin
 	@Setter(AccessLevel.PACKAGE)
 	private int finishId;
 
+	@Getter
+	@Setter
+	private Set<Integer> previousShownTrailIds;
+
+	@Getter
+	@Setter
+	private Integer previousTrailId = null;
+
+	@Getter
+	@Setter
+	private WorldPoint herbiboarLocation = null;
+
 	@Getter(AccessLevel.PACKAGE)
 	private boolean isStartShown;
 	@Getter(AccessLevel.PACKAGE)
@@ -164,6 +179,8 @@ public class HerbiboarPlugin extends Plugin
 	private boolean isTrailShown;
 	@Getter(AccessLevel.PACKAGE)
 	private Color getTrailColor;
+	@Getter(AccessLevel.PACKAGE)
+	private boolean isOnlyCurrentTrailShown;
 
 	@Provides
 	HerbiboarConfig getConfig(ConfigManager configManager)
@@ -196,6 +213,7 @@ public class HerbiboarPlugin extends Plugin
 		eventBus.subscribe(ConfigChanged.class, this, this::onConfigChanged);
 		eventBus.subscribe(GameStateChanged.class, this, this::onGameStateChanged);
 		eventBus.subscribe(VarbitChanged.class, this, this::onVarbitChanged);
+		eventBus.subscribe(AnimationChanged.class, this, this::onAnimationChanged);
 		eventBus.subscribe(GameObjectSpawned.class, this, this::onGameObjectSpawned);
 		eventBus.subscribe(GameObjectChanged.class, this, this::onGameObjectChanged);
 		eventBus.subscribe(GameObjectDespawned.class, this, this::onGameObjectDespawned);
@@ -242,6 +260,44 @@ public class HerbiboarPlugin extends Plugin
 		{
 			resetTrailData();
 		}
+
+	}
+
+	public Set<Integer> getCurrentTrailIds()
+	{
+		Set<Integer> shownTrailIds;
+		if (currentTrail == null)
+		{
+			if (finishId <= 0)
+			{
+				previousTrailId = null;
+				shownTrailIds = new HashSet<>();
+			}
+			else
+			{
+				shownTrailIds = new HashSet<>();
+				shownTrailIds.add(previousTrailId);
+				shownTrailIds.add(previousTrailId + 1);
+			}
+		}
+		else if (previousTrailId == null)
+		{
+			previousTrailId = currentTrail.getTrailId();
+			shownTrailIds = getShownTrails();
+		}
+		else if (currentTrail.getTrailId() == previousTrailId)
+		{
+			shownTrailIds = previousShownTrailIds;
+		}
+		else
+		{
+			shownTrailIds = new HashSet<>();
+			shownTrailIds.add(previousTrailId);
+			shownTrailIds.add(previousTrailId + 1);
+			previousTrailId = currentTrail.getTrailId();
+		}
+		previousShownTrailIds = shownTrailIds;
+		return shownTrailIds;
 	}
 
 	private void resetTrailData()
@@ -288,6 +344,31 @@ public class HerbiboarPlugin extends Plugin
 	private void onGameObjectSpawned(GameObjectSpawned event)
 	{
 		onGameObject(event.getTile(), null, event.getGameObject());
+	}
+
+	public void onAnimationChanged(AnimationChanged event)
+	{
+		if (!(event.getActor() instanceof NPC))
+		{
+			return;
+		}
+
+		NPC npc = (NPC) event.getActor();
+		// Herbiboar spawns
+		if (npc.getId() == NpcID.HERBIBOAR_7786 && npc.getAnimation() == 7687)
+		{
+			herbiboarLocation = npc.getWorldLocation();
+		}
+		// Herbiboar is stunned
+		else if (npc.getId() == NpcID.HERBIBOAR && npc.getAnimation() == 7689)
+		{
+			herbiboarLocation = npc.getWorldLocation();
+		}
+		// Herbiboar is harvested
+		else if (npc.getId() == NpcID.HERBIBOAR_7786 && npc.getAnimation() == 7690)
+		{
+			herbiboarLocation = null;
+		}
 	}
 
 	private void onGameObjectChanged(GameObjectChanged event)
@@ -412,5 +493,6 @@ public class HerbiboarPlugin extends Plugin
 		this.getObjectColor = config.getObjectColor();
 		this.isTrailShown = config.isTrailShown();
 		this.getTrailColor = config.getTrailColor();
+		this.isOnlyCurrentTrailShown = config.isOnlyCurrentTrailShown();
 	}
 }


### PR DESCRIPTION
Fixes #1508 
Requires #1489 
(Well, not really requires, but I've based this PR off of that code, and with config changes, it's nice to have that merged first to avoid conflicts)

This addresses FPS drops on Fossil Island by disabling the option to show clickboxes for start locations, trail objects and tunnels. The plugin will now only highlight the tile the object is on. This increases performance from 15 FPS to 40-50 on my machine. (i5-7300HQ, GTX 1060 3GB).

One could argue that players should have the option to show clickboxes, but it makes no sense to have them without a warning that it causes severe FPS drops. The clickboxes should either be optimized in some other way to not cause FPS drops, or the option should be disabled imo.