### PR TITLE
playerindicators: prioritize clan and friends over targets

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -63,18 +63,19 @@ public class PlayerIndicatorsService
 		clan = Player::isClanMember;
 		team = (player) -> (Objects.requireNonNull(client.getLocalPlayer()).getTeam() != 0 &&
 			client.getLocalPlayer().getTeam() == player.getTeam());
-		target = (player) -> PvPUtil.isAttackable(client, player);
+		target = (player ->
+		{
+			if (nonFriendly(player))
+			{
+				return false;
+			}
+			return PvPUtil.isAttackable(client, player);
+		});
 		caller = plugin::isCaller;
 		callerTarget = piles::contains;
 		other = (player ->
 		{
-			if (player == null
-				|| (plugin.isHighlightClan() && player.isClanMember())
-				|| (plugin.isHighlightFriends() && client.isFriended(player.getName(), false))
-				|| (plugin.isHighlightCallers() && plugin.isCaller(player))
-				|| (plugin.isHighlightCallerTargets() && piles.contains(player))
-				|| (plugin.isHighlightTeam() && Objects.requireNonNull(client.getLocalPlayer()).getTeam() != 0
-				&& client.getLocalPlayer().getTeam() == player.getTeam()))
+			if (nonFriendly(player))
 			{
 				return false;
 			}
@@ -140,5 +141,16 @@ public class PlayerIndicatorsService
 		return plugin.isHighlightOwnPlayer() || plugin.isHighlightClan()
 			|| plugin.isHighlightFriends() || plugin.isHighlightOther() || plugin.isHighlightTargets()
 			|| plugin.isHighlightCallers() || plugin.isHighlightTeam() || plugin.isHighlightCallerTargets();
+	}
+
+	private boolean nonFriendly(Player player)
+	{
+		return player == null
+			|| (plugin.isHighlightClan() && player.isClanMember())
+			|| (plugin.isHighlightFriends() && client.isFriended(player.getName(), false))
+			|| (plugin.isHighlightCallers() && plugin.isCaller(player))
+			|| (plugin.isHighlightCallerTargets() && piles.contains(player))
+			|| (plugin.isHighlightTeam() && Objects.requireNonNull(client.getLocalPlayer()).getTeam() != 0
+			&& client.getLocalPlayer().getTeam() == player.getTeam());
 	}
 }

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsService.java
@@ -60,7 +60,7 @@ public class PlayerIndicatorsService
 
 		self = (player) -> Objects.equals(client.getLocalPlayer(), player);
 		friend = (player) -> (!player.equals(client.getLocalPlayer()) && client.isFriended(player.getName(), false));
-		clan = Player::isClanMember;
+		clan = (player) -> (player.isClanMember() && !client.isFriended(player.getName(), false));
 		team = (player) -> (Objects.requireNonNull(client.getLocalPlayer()).getTeam() != 0 &&
 			client.getLocalPlayer().getTeam() == player.getTeam());
 		target = (player ->
@@ -69,7 +69,7 @@ public class PlayerIndicatorsService
 			{
 				return false;
 			}
-			return PvPUtil.isAttackable(client, player);
+			return plugin.isHighlightTargets() && PvPUtil.isAttackable(client, player);
 		});
 		caller = plugin::isCaller;
 		callerTarget = piles::contains;
@@ -79,7 +79,7 @@ public class PlayerIndicatorsService
 			{
 				return false;
 			}
-			return !plugin.isHighlightTargets() || PvPUtil.isAttackable(client, player);
+			return true;
 		});
 	}
 


### PR DESCRIPTION
Adds friendly priority to targets so they will be highlighted as friends/clan/team/callers/piles before being highlighted as a target

Signed-off-by: PKLite <stonewall@pklite.xyz>