### PR TITLE
playerindicators: fix agility icon spacing

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -161,7 +161,6 @@ public class PlayerIndicatorsOverlay extends Overlay
 			if (plugin.getAgilityFormat() == PlayerIndicatorsPlugin.AgilityFormats.ICONS)
 			{
 
-
 				final int width;
 				if (plugin.isShowCombatLevel())
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -161,16 +161,9 @@ public class PlayerIndicatorsOverlay extends Overlay
 			if (plugin.getAgilityFormat() == PlayerIndicatorsPlugin.AgilityFormats.ICONS)
 			{
 
-				final int width;
-				if (plugin.isShowCombatLevel())
-				{
-					width = graphics.getFontMetrics().stringWidth(name) + 10;
-				}
-				else
-				{
-					width = graphics.getFontMetrics().stringWidth(name);
+				final int width = plugin.isShowCombatLevel() ? graphics.getFontMetrics().stringWidth(name)
+					+ ACTOR_HORIZONTAL_TEXT_MARGIN : graphics.getFontMetrics().stringWidth(name);
 
-				}
 				final int height = graphics.getFontMetrics().getHeight();
 				if (level >= plugin.getAgilityFirstThreshold())
 				{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsOverlay.java
@@ -160,7 +160,18 @@ public class PlayerIndicatorsOverlay extends Overlay
 
 			if (plugin.getAgilityFormat() == PlayerIndicatorsPlugin.AgilityFormats.ICONS)
 			{
-				final int width = graphics.getFontMetrics().stringWidth(name);
+
+
+				final int width;
+				if (plugin.isShowCombatLevel())
+				{
+					width = graphics.getFontMetrics().stringWidth(name) + 10;
+				}
+				else
+				{
+					width = graphics.getFontMetrics().stringWidth(name);
+
+				}
 				final int height = graphics.getFontMetrics().getHeight();
 				if (level >= plugin.getAgilityFirstThreshold())
 				{


### PR DESCRIPTION
closes #1516 
Added a spacer of 10px if combat level is enabled to prevent the icon being squished.