### PR TITLE
grounditems: Enable text outline by default

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsConfig.java
@@ -605,15 +605,15 @@ public interface GroundItemsConfig extends Config
 	}
 
 	@ConfigItem(
-		keyName = "toggleOutline",
+		keyName = "enableOutline",
 		name = "Text Outline",
 		description = "Use an outline around text instead of a text shadow",
 		position = 47,
 		parent = "miscStub"
 	)
-	default boolean toggleOutline()
+	default boolean enableOutline()
 	{
-		return false;
+		return true;
 	}
 
 	@ConfigItem(

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsOverlay.java
@@ -378,7 +378,7 @@ public class GroundItemsOverlay extends Overlay
 				drawTimerOverlay(graphics, new java.awt.Point(textX, textY), item);
 			}
 
-			if (plugin.isToggleOutline())
+			if (plugin.isEnableOutline())
 			{
 				final Color bordercolor = plugin.getBordercolor();
 				graphics.setColor(bordercolor);

--- a/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/grounditems/GroundItemsPlugin.java
@@ -220,7 +220,7 @@ public class GroundItemsPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private int doubleTapDelay;
 	@Getter(AccessLevel.PACKAGE)
-	private boolean toggleOutline;
+	private boolean enableOutline;
 	@Getter(AccessLevel.PACKAGE)
 	private boolean showTimer;
 	@Getter(AccessLevel.PACKAGE)
@@ -1019,7 +1019,7 @@ public class GroundItemsPlugin extends Plugin
 		this.onlyShowLoot = config.onlyShowLoot();
 		this.showGroundItemDuration = config.showGroundItemDuration();
 		this.doubleTapDelay = config.doubleTapDelay();
-		this.toggleOutline = config.toggleOutline();
+		this.enableOutline = config.enableOutline();
 		this.showTimer = config.showTimer();
 		this.bordercolor = config.bordercolor();
 	}


### PR DESCRIPTION
Makes ground items much more legible. And is now enabled by default.

![image](https://user-images.githubusercontent.com/2943260/64227838-f582c780-ceb2-11e9-898a-0c304413054b.png)
