### PR TITLE
configinvocationhandler: Set config to default if string to object fails and it's a default method

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
+++ b/runelite-client/src/main/java/net/runelite/client/config/ConfigInvocationHandler.java
@@ -115,7 +115,11 @@ class ConfigInvocationHandler implements InvocationHandler
 						log.warn("Unable to unmarshal {}.{} ", groupValue, itemKeyName, e);
 						if (method.isDefault())
 						{
-							return callDefaultMethod(proxy, method, null);
+							Object defaultValue = callDefaultMethod(proxy, method, null);
+
+							manager.setConfiguration(groupValue, itemKeyName, defaultValue);
+
+							return defaultValue;
 						}
 						return null;
 					}


### PR DESCRIPTION
Closes #1518

This adds back #455