### PR TITLE
freezetimers: fix veng timer

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/Timers.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/freezetimers/Timers.java
@@ -87,16 +87,6 @@ public class Timers
 		{
 			final Actor actor = it.next();
 
-			for (TimerType timerType : TimerType.values())
-			{
-				if (getTimerReApply(actor, timerType) > System.currentTimeMillis())
-				{
-					break;
-				}
-				it.remove();
-				break;
-			}
-
 			final long end = getTimerReApply(actor, type);
 
 			if (end > System.currentTimeMillis())


### PR DESCRIPTION
for loop wasnt being utilised properly and broke veng timers.

ran for 30 mins and 0 CME's, even with players running off screen, being frozen, teleporting etc.