### PR TITLE
rsmodelmixin: add assertion for convex hull.

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSModelMixin.java
@@ -323,6 +323,8 @@ public abstract class RSModelMixin implements RSModel
 	@Inject
 	public Polygon getConvexHull(int localX, int localY, int orientation, int tileHeight)
 	{
+		assert client.isClientThread();
+
 		List<Vertex> vertices = getVertices();
 
 		// rotate vertices


### PR DESCRIPTION
If you call getConvexHull on a new thread, it can return with an IndexOutOfBoundsException.