### PR TITLE
npchider: change method by which npcs are hidden by name

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1485,11 +1485,25 @@ public interface Client extends GameShell
 	void forciblyUnhideNpcName(String name);
 
 	/**
-	 * Sets which NPCs are hidden on death
+	 * Increments the counter for how many times this npc has been selected to be hidden on death
 	 *
-	 * @param names the names of the npcs
+	 * @param name npc name
 	 */
-	void setNPCsHiddenOnDeath(List<String> names);
+	void addHiddenNpcDeath(String name);
+
+	/**
+	 * Decrements the counter for how many times this npc has been selected to be hidden on death
+	 *
+	 * @param name npc name
+	 */
+	void removeHiddenNpcDeath(String name);
+
+	/**
+	 * Forcibly unhides a hidden-while-dead npc by setting its counter to zero
+	 *
+	 * @param name npc name
+	 */
+	void forciblyUnhideNpcDeath(String name);
 
 	/**
 	 * Sets whether 2D sprites (ie. overhead prayers) related to

--- a/runelite-api/src/main/java/net/runelite/api/Client.java
+++ b/runelite-api/src/main/java/net/runelite/api/Client.java
@@ -1464,11 +1464,25 @@ public interface Client extends GameShell
 	void setNPCsHidden(boolean state);
 
 	/**
-	 * Sets which NPCs are hidden
+	 * Increments the counter for how many times this npc has been selected to be hidden
 	 *
-	 * @param names the names of the npcs
+	 * @param name npc name
 	 */
-	void setNPCsNames(List<String> names);
+	void addHiddenNpcName(String name);
+
+	/**
+	 * Decrements the counter for how many times this npc has been selected to be hidden
+	 *
+	 * @param name npc name
+	 */
+	void removeHiddenNpcName(String name);
+
+	/**
+	 * Forcibly unhides an npc by setting its counter to zero
+	 *
+	 * @param name npc name
+	 */
+	void forciblyUnhideNpcName(String name);
 
 	/**
 	 * Sets which NPCs are hidden on death

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -73,6 +73,8 @@ public class EntityHiderPlugin extends Plugin
 	{
 		updateConfig();
 		addSubscriptions();
+
+		Text.fromCSV(config.hideNPCsNames()).forEach(client::addHiddenNpcName);
 	}
 
 	private void addSubscriptions()
@@ -159,6 +161,8 @@ public class EntityHiderPlugin extends Plugin
 		client.setProjectilesHidden(false);
 
 		client.setDeadNPCsHidden(false);
+
+		Text.fromCSV(config.hideNPCsNames()).forEach(client::removeHiddenNpcName);
 	}
 
 	private boolean isPlayerRegionAllowed()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2019, ThatGamerBlue <thatgamerblue@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -75,6 +76,7 @@ public class EntityHiderPlugin extends Plugin
 		addSubscriptions();
 
 		Text.fromCSV(config.hideNPCsNames()).forEach(client::addHiddenNpcName);
+		Text.fromCSV(config.hideNPCsOnDeath()).forEach(client::addHiddenNpcDeath);
 	}
 
 	private void addSubscriptions()
@@ -99,6 +101,18 @@ public class EntityHiderPlugin extends Plugin
 
 				removed.forEach(client::removeHiddenNpcName);
 				added.forEach(client::addHiddenNpcName);
+			}
+
+			if (event.getKey().equals("hideNPCsOnDeath"))
+			{
+				List<String> oldList = Text.fromCSV(event.getOldValue());
+				List<String> newList = Text.fromCSV(event.getNewValue());
+
+				ArrayList<String> removed = oldList.stream().filter(s -> !newList.contains(s)).collect(Collectors.toCollection(ArrayList::new));
+				ArrayList<String> added = newList.stream().filter(s -> !oldList.contains(s)).collect(Collectors.toCollection(ArrayList::new));
+
+				removed.forEach(client::removeHiddenNpcDeath);
+				added.forEach(client::addHiddenNpcDeath);
 			}
 		}
 	}
@@ -128,7 +142,7 @@ public class EntityHiderPlugin extends Plugin
 		client.setNPCsHidden(config.hideNPCs());
 		client.setNPCsHidden2D(config.hideNPCs2D());
 		//client.setNPCsNames(Text.fromCSV(config.hideNPCsNames()));
-		client.setNPCsHiddenOnDeath(Text.fromCSV(config.hideNPCsOnDeath()));
+		//client.setNPCsHiddenOnDeath(Text.fromCSV(config.hideNPCsOnDeath()));
 
 		client.setAttackersHidden(config.hideAttackers());
 
@@ -163,6 +177,7 @@ public class EntityHiderPlugin extends Plugin
 		client.setDeadNPCsHidden(false);
 
 		Text.fromCSV(config.hideNPCsNames()).forEach(client::removeHiddenNpcName);
+		Text.fromCSV(config.hideNPCsOnDeath()).forEach(client::removeHiddenNpcDeath);
 	}
 
 	private boolean isPlayerRegionAllowed()

--- a/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/entityhider/EntityHiderPlugin.java
@@ -40,6 +40,10 @@ import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @PluginDescriptor(
 	name = "Entity Hider",
 	description = "Hide players, NPCs, and/or projectiles",
@@ -82,6 +86,18 @@ public class EntityHiderPlugin extends Plugin
 		if (event.getGroup().equals("entityhider"))
 		{
 			updateConfig();
+
+			if (event.getKey().equals("hideNPCsNames"))
+			{
+				List<String> oldList = Text.fromCSV(event.getOldValue());
+				List<String> newList = Text.fromCSV(event.getNewValue());
+
+				ArrayList<String> removed = oldList.stream().filter(s -> !newList.contains(s)).collect(Collectors.toCollection(ArrayList::new));
+				ArrayList<String> added = newList.stream().filter(s -> !oldList.contains(s)).collect(Collectors.toCollection(ArrayList::new));
+
+				removed.forEach(client::removeHiddenNpcName);
+				added.forEach(client::addHiddenNpcName);
+			}
 		}
 	}
 
@@ -109,7 +125,7 @@ public class EntityHiderPlugin extends Plugin
 
 		client.setNPCsHidden(config.hideNPCs());
 		client.setNPCsHidden2D(config.hideNPCs2D());
-		client.setNPCsNames(Text.fromCSV(config.hideNPCsNames()));
+		//client.setNPCsNames(Text.fromCSV(config.hideNPCsNames()));
 		client.setNPCsHiddenOnDeath(Text.fromCSV(config.hideNPCsOnDeath()));
 
 		client.setAttackersHidden(config.hideAttackers());

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.mixins;
 
+import java.util.HashMap;
 import java.util.List;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
@@ -69,7 +70,7 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public static boolean hideDeadNPCs;
 
 	@Inject
-	public static List<String> hideNPCsNames;
+	public static HashMap<String, Integer> hiddenNpcs;
 
 	@Inject
 	public static List<String> hideNPCsOnDeath;
@@ -142,9 +143,38 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 
 	@Inject
 	@Override
-	public void setNPCsNames(List<String> NPCs)
+	public void addHiddenNpcName(String npc)
 	{
-		hideNPCsNames = NPCs;
+		npc = npc.toLowerCase();
+		int i = hiddenNpcs.getOrDefault(npc, 0);
+		if (i == Integer.MAX_VALUE)
+		{
+			throw new RuntimeException("NPC " + npc + " has been hidden Integer.MAX_VALUE times, is something wrong?");
+		}
+
+		hiddenNpcs.put(npc, ++i);
+	}
+
+	@Inject
+	@Override
+	public void removeHiddenNpcName(String npc)
+	{
+		npc = npc.toLowerCase();
+		int i = hiddenNpcs.getOrDefault(npc, 0);
+		if (i == 0)
+		{
+			return;
+		}
+
+		hiddenNpcs.put(npc, --i);
+	}
+
+	@Inject
+	@Override
+	public void forciblyUnhideNpcName(String npc)
+	{
+		npc = npc.toLowerCase();
+		hiddenNpcs.put(npc, 0);
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderBridgeMixin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2019, ThatGamerBlue <thatgamerblue@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,6 +25,7 @@
  */
 package net.runelite.mixins;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import net.runelite.api.mixins.Inject;
@@ -70,13 +72,13 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public static boolean hideDeadNPCs;
 
 	@Inject
-	public static HashMap<String, Integer> hiddenNpcs;
+	public static HashMap<String, Integer> hiddenNpcsName = new HashMap<>();
 
 	@Inject
-	public static List<String> hideNPCsOnDeath;
+	public static HashMap<String, Integer> hiddenNpcsDeath = new HashMap<>();
 
 	@Inject
-	public static List<String> hideSpecificPlayers;
+	public static List<String> hideSpecificPlayers = new ArrayList<>();
 
 	@Inject
 	@Override
@@ -146,13 +148,13 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public void addHiddenNpcName(String npc)
 	{
 		npc = npc.toLowerCase();
-		int i = hiddenNpcs.getOrDefault(npc, 0);
+		int i = hiddenNpcsName.getOrDefault(npc, 0);
 		if (i == Integer.MAX_VALUE)
 		{
-			throw new RuntimeException("NPC " + npc + " has been hidden Integer.MAX_VALUE times, is something wrong?");
+			throw new RuntimeException("NPC name " + npc + " has been hidden Integer.MAX_VALUE times, is something wrong?");
 		}
 
-		hiddenNpcs.put(npc, ++i);
+		hiddenNpcsName.put(npc, ++i);
 	}
 
 	@Inject
@@ -160,13 +162,13 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public void removeHiddenNpcName(String npc)
 	{
 		npc = npc.toLowerCase();
-		int i = hiddenNpcs.getOrDefault(npc, 0);
+		int i = hiddenNpcsName.getOrDefault(npc, 0);
 		if (i == 0)
 		{
 			return;
 		}
 
-		hiddenNpcs.put(npc, --i);
+		hiddenNpcsName.put(npc, --i);
 	}
 
 	@Inject
@@ -174,14 +176,43 @@ public abstract class EntityHiderBridgeMixin implements RSClient
 	public void forciblyUnhideNpcName(String npc)
 	{
 		npc = npc.toLowerCase();
-		hiddenNpcs.put(npc, 0);
+		hiddenNpcsName.put(npc, 0);
 	}
 
 	@Inject
 	@Override
-	public void setNPCsHiddenOnDeath(List<String> NPCs)
+	public void addHiddenNpcDeath(String npc)
 	{
-		hideNPCsOnDeath = NPCs;
+		npc = npc.toLowerCase();
+		int i = hiddenNpcsDeath.getOrDefault(npc, 0);
+		if (i == Integer.MAX_VALUE)
+		{
+			throw new RuntimeException("NPC death " + npc + " has been hidden Integer.MAX_VALUE times, is something wrong?");
+		}
+
+		hiddenNpcsDeath.put(npc, ++i);
+	}
+
+	@Inject
+	@Override
+	public void removeHiddenNpcDeath(String npc)
+	{
+		npc = npc.toLowerCase();
+		int i = hiddenNpcsDeath.getOrDefault(npc, 0);
+		if (i == 0)
+		{
+			return;
+		}
+
+		hiddenNpcsDeath.put(npc, --i);
+	}
+
+	@Inject
+	@Override
+	public void forciblyUnhideNpcDeath(String npc)
+	{
+		npc = npc.toLowerCase();
+		hiddenNpcsDeath.put(npc, 0);
 	}
 
 	@Inject

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018, Lotto <https://github.com/devLotto>
+ * Copyright (c) 2019, ThatGamerBlue <thatgamerblue@gmail.com>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,46 +41,55 @@ import net.runelite.rs.api.RSScene;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Mixin(RSScene.class)
 public abstract class EntityHiderMixin implements RSScene
 {
-	@Inject
-	private static final Pattern WILDCARD_PATTERN = Pattern.compile("(?i)[^*]+|(\\*)");
-	@Inject
-	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
 	@Shadow("client")
 	private static RSClient client;
+
 	@Shadow("isHidingEntities")
 	private static boolean isHidingEntities;
+
 	@Shadow("hidePlayers")
 	private static boolean hidePlayers;
+
 	@Shadow("hidePlayers2D")
 	private static boolean hidePlayers2D;
+
 	@Shadow("hideFriends")
 	private static boolean hideFriends;
+
 	@Shadow("hideClanMates")
 	private static boolean hideClanMates;
+
 	@Shadow("hideLocalPlayer")
 	private static boolean hideLocalPlayer;
+
 	@Shadow("hideLocalPlayer2D")
 	private static boolean hideLocalPlayer2D;
+
 	@Shadow("hideNPCs")
 	private static boolean hideNPCs;
-	@Shadow("hiddenNpcs")
-	private static HashMap<String, Integer> hiddenNpcs;
-	@Shadow("hideNPCsOnDeath")
-	private static List<String> hideNPCsOnDeath;
+
+	@Shadow("hiddenNpcsName")
+	private static HashMap<String, Integer> hiddenNpcsName;
+
+	@Shadow("hiddenNpcsDeath")
+	private static HashMap<String, Integer> hiddenNpcsDeath;
+
 	@Shadow("hideSpecificPlayers")
 	private static List<String> hideSpecificPlayers;
+
 	@Shadow("hideNPCs2D")
 	private static boolean hideNPCs2D;
+
 	@Shadow("hideAttackers")
 	private static boolean hideAttackers;
+
 	@Shadow("hideProjectiles")
 	private static boolean hideProjectiles;
+
 	@Shadow("hideDeadNPCs")
 	private static boolean hideDeadNPCs;
 
@@ -184,20 +194,16 @@ public abstract class EntityHiderMixin implements RSScene
 				return false;
 			}
 
-			if (npc.getName() != null && hiddenNpcs.getOrDefault(Text.standardize(npc.getName().toLowerCase()), 0) > 0)
+			if (npc.getName() != null &&
+				hiddenNpcsName.getOrDefault(Text.standardize(npc.getName().toLowerCase()), 0) > 0)
 			{
 				return false;
 			}
 
-			for (String name : hideNPCsOnDeath)
+			if (npc.getName() != null && npc.getHealthRatio() == 0 &&
+				hiddenNpcsDeath.getOrDefault(Text.standardize(npc.getName().toLowerCase()), 0) > 0)
 			{
-				if (name != null && !name.equals(""))
-				{
-					if (npc.getName() != null && matches(name, npc.getName()) && npc.getHealthRatio() == 0)
-					{
-						return false;
-					}
-				}
+				return false;
 			}
 
 			return drawingUI ? !hideNPCs2D : !hideNPCs;
@@ -208,35 +214,5 @@ public abstract class EntityHiderMixin implements RSScene
 		}
 
 		return true;
-	}
-
-	@Inject
-	static private boolean matches(String pattern, String text)
-	{
-		String standardized = TAG_REGEXP.matcher(text)
-			.replaceAll("")
-			.replace('\u00A0', ' ')
-			.toLowerCase();
-
-		final Matcher matcher = WILDCARD_PATTERN.matcher(pattern.toLowerCase());
-		final StringBuffer buffer = new StringBuffer();
-
-		buffer.append("(?i)");
-		while (matcher.find())
-		{
-			if (matcher.group(1) != null)
-			{
-				matcher.appendReplacement(buffer, ".*");
-			}
-			else
-			{
-				matcher.appendReplacement(buffer, "\\\\Q" + matcher.group(0) + "\\\\E");
-			}
-		}
-
-		matcher.appendTail(buffer);
-		final String replaced = buffer.toString();
-
-		return standardized.matches(replaced);
 	}
 }

--- a/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/EntityHiderMixin.java
@@ -24,9 +24,6 @@
  */
 package net.runelite.mixins;
 
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
@@ -41,60 +38,48 @@ import net.runelite.rs.api.RSPlayer;
 import net.runelite.rs.api.RSProjectile;
 import net.runelite.rs.api.RSScene;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 @Mixin(RSScene.class)
 public abstract class EntityHiderMixin implements RSScene
 {
 	@Inject
 	private static final Pattern WILDCARD_PATTERN = Pattern.compile("(?i)[^*]+|(\\*)");
-
 	@Inject
 	private static final Pattern TAG_REGEXP = Pattern.compile("<[^>]*>");
-
 	@Shadow("client")
 	private static RSClient client;
-
 	@Shadow("isHidingEntities")
 	private static boolean isHidingEntities;
-
 	@Shadow("hidePlayers")
 	private static boolean hidePlayers;
-
 	@Shadow("hidePlayers2D")
 	private static boolean hidePlayers2D;
-
 	@Shadow("hideFriends")
 	private static boolean hideFriends;
-
 	@Shadow("hideClanMates")
 	private static boolean hideClanMates;
-
 	@Shadow("hideLocalPlayer")
 	private static boolean hideLocalPlayer;
-
 	@Shadow("hideLocalPlayer2D")
 	private static boolean hideLocalPlayer2D;
-
 	@Shadow("hideNPCs")
 	private static boolean hideNPCs;
-
-	@Shadow("hideNPCsNames")
-	private static List<String> hideNPCsNames;
-
+	@Shadow("hiddenNpcs")
+	private static HashMap<String, Integer> hiddenNpcs;
 	@Shadow("hideNPCsOnDeath")
 	private static List<String> hideNPCsOnDeath;
-
 	@Shadow("hideSpecificPlayers")
 	private static List<String> hideSpecificPlayers;
-
 	@Shadow("hideNPCs2D")
 	private static boolean hideNPCs2D;
-
 	@Shadow("hideAttackers")
 	private static boolean hideAttackers;
-
 	@Shadow("hideProjectiles")
 	private static boolean hideProjectiles;
-
 	@Shadow("hideDeadNPCs")
 	private static boolean hideDeadNPCs;
 
@@ -117,7 +102,8 @@ public abstract class EntityHiderMixin implements RSScene
 			client.getOccupiedTilesTick()[tileX][tileY] = -1;
 		}
 
-		return shouldDraw && addEntityMarker(var1, var2, var3, var4, var5, x, y, var8, entity, var10, var11, var12, var13);
+		return shouldDraw &&
+			addEntityMarker(var1, var2, var3, var4, var5, x, y, var8, entity, var10, var11, var12, var13);
 	}
 
 	@Copy("drawActor2d")
@@ -177,7 +163,8 @@ public abstract class EntityHiderMixin implements RSScene
 					return false;
 				}
 
-				return (!hideFriends && player.isFriend()) || (!isLocalPlayer && !hideClanMates && player.isClanMember());
+				return (!hideFriends && player.isFriend()) ||
+					(!isLocalPlayer && !hideClanMates && player.isClanMember());
 			}
 		}
 		else if (entity instanceof RSNPC)
@@ -197,15 +184,9 @@ public abstract class EntityHiderMixin implements RSScene
 				return false;
 			}
 
-			for (String name : hideNPCsNames)
+			if (npc.getName() != null && hiddenNpcs.getOrDefault(Text.standardize(npc.getName().toLowerCase()), 0) > 0)
 			{
-				if (name != null && !name.equals(""))
-				{
-					if (npc.getName() != null && matches(name, npc.getName()))
-					{
-						return false;
-					}
-				}
+				return false;
 			}
 
 			for (String name : hideNPCsOnDeath)


### PR DESCRIPTION
Changes Entity Hider to keep track of how many plugins wish to hide an entity, only unhiding it once all plugins have released their locks.