### PR TITLE
modeloutline: Use rotation instead of orientation

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -112,6 +112,8 @@ public interface Actor extends Entity
 	 */
 	int getOrientation();
 
+	int getCurrentOrientation();
+
 	/**
 	 * Gets the current animation the actor is performing.
 	 *

--- a/runelite-client/src/main/java/net/runelite/client/graphics/ModelOutlineRenderer.java
+++ b/runelite-client/src/main/java/net/runelite/client/graphics/ModelOutlineRenderer.java
@@ -948,7 +948,7 @@ public class ModelOutlineRenderer
 
 			drawModelOutline(npc.getModel(), lp.getX(), lp.getY(),
 				Perspective.getTileHeight(client, northEastLp, client.getPlane()),
-				npc.getOrientation(), outlineWidth, innerColor, outerColor);
+				npc.getCurrentOrientation(), outlineWidth, innerColor, outerColor);
 		}
 	}
 
@@ -964,7 +964,7 @@ public class ModelOutlineRenderer
 		{
 			drawModelOutline(player.getModel(), lp.getX(), lp.getY(),
 				Perspective.getTileHeight(client, lp, client.getPlane()),
-				player.getOrientation(), outlineWidth, innerColor, outerColor);
+				player.getCurrentOrientation(), outlineWidth, innerColor, outerColor);
 		}
 	}
 

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSActor.java
@@ -127,6 +127,10 @@ public interface RSActor extends RSEntity, Actor
 	@Override
 	int getOrientation();
 
+	@Import("rotation")
+	@Override
+	int getCurrentOrientation();
+
 	// Health stuff
 
 	@Import("healthBars")


### PR DESCRIPTION
Orientation lags behind most of the times while rotation doesn't