### PR TITLE
Raids: Add missing layout

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/raids/RaidsPlugin.java
@@ -139,7 +139,8 @@ public class RaidsPlugin extends Plugin
 		"SFCCS.PCPSF - #ENWWSW#ENESEN", //bad crabs first good crabs second
 		"SPCFC.SCCPF - #ESENES#WWWNEE", //bad crabs first good crabs second
 		"SPSFP.CCCSF - #NWSWWN#ESEENW", //bad crabs first good crabs second
-		"FSCCP.PCSCF - #ENWWWS#NEESEN" //bad crabs first good crabs second
+		"FSCCP.PCSCF - #ENWWWS#NEESEN", //bad crabs first good crabs second
+		"FSCCS.PCPSF - #WSEEEN#WSWNWS" //bad crabs first good crabs second
 	);
 	private static final ImmutableSet<String> RARE_CRABS_FIRST = ImmutableSet.of(
 		"SCPFC.CSPCF - #NEEESW#WWNEEE", //rare crabs first good crabs second


### PR DESCRIPTION
"FSCCS.PCPSF - #WSEEEN#WSWNWS"

This layout was missing so returning Bad crabs when it should follow the normal rules - bad crabs first good crabs seconds.