### PR TITLE
Less Obnoxious WhaleWatchers Overlay 

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersConfig.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersConfig.java
@@ -21,6 +21,17 @@ public interface WhaleWatchersConfig extends Config
 
 	@ConfigItem(
 		position = 2,
+		keyName = "lessObnoxiousProtWarning",
+		name = "Less Obnoxious Protect Item Warning",
+		description = "Replaces the overlay with thick border and text with a less obtrusive overlay with a thin border and no text"
+	)
+	default boolean lessObnoxiousProtWarning()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+		position = 3,
 		keyName = "showDamageCounter",
 		name = "Damage Counter",
 		description = "Shows damage you've done and damage your opponent has done to you while in a fight"
@@ -31,7 +42,7 @@ public interface WhaleWatchersConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 3,
+		position = 4,
 		keyName = "smiteableWarning",
 		name = "Smite Warning",
 		description = "Displays a warning overlay when your prayer is at a smiteable level"
@@ -42,7 +53,7 @@ public interface WhaleWatchersConfig extends Config
 	}
 
 	@ConfigItem(
-		position = 4,
+		position = 5,
 		keyName = "gloryWarning",
 		name = "Glory Warning",
 		description = "Displays a warning box while you are wearing an uncharged glory"

--- a/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersPlugin.java
@@ -87,6 +87,8 @@ public class WhaleWatchersPlugin extends Plugin
 	@Getter(AccessLevel.PACKAGE)
 	private boolean protectItemWarning;
 	@Getter(AccessLevel.PACKAGE)
+	private boolean lessObnoxiousProtWarning;
+	@Getter(AccessLevel.PACKAGE)
 	private boolean showDamageCounter;
 	private boolean smiteableWarning;
 	private boolean gloryWarning;
@@ -303,6 +305,7 @@ public class WhaleWatchersPlugin extends Plugin
 	private void updateConfig()
 	{
 		this.protectItemWarning = config.protectItemWarning();
+		this.lessObnoxiousProtWarning = config.lessObnoxiousProtWarning();
 		this.showDamageCounter = config.showDamageCounter();
 		this.smiteableWarning = config.smiteableWarning();
 		this.gloryWarning = config.gloryWarning();

--- a/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersProtOverlay.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/whalewatchers/WhaleWatchersProtOverlay.java
@@ -56,12 +56,22 @@ public class WhaleWatchersProtOverlay extends Overlay
 			rectangle.setBounds(client.getCanvas().getBounds());
 			rectangle.setLocation(client.getCanvas().getLocation());
 			Stroke oldStroke = graphics.getStroke();
-			graphics.setStroke(new BasicStroke(10));
+			if (plugin.isLessObnoxiousProtWarning())
+			{
+				graphics.setStroke(new BasicStroke(3));
+			}
+			else
+			{
+				graphics.setStroke(new BasicStroke(10));
+			}
 			graphics.setColor(Color.RED);
 			graphics.draw(rectangle);
-			Font font = FontManager.getRunescapeBoldFont().deriveFont(Font.BOLD, 72);
-			graphics.setFont(font);
-			OverlayUtil.renderTextLocation(graphics, new Point((int) rectangle.getCenterX() - 50, font.getSize()), "Protect item prayer disabled!!!", Color.red);
+			if (!plugin.isLessObnoxiousProtWarning())
+			{
+				Font font = FontManager.getRunescapeBoldFont().deriveFont(Font.BOLD, 72);
+				graphics.setFont(font);
+				OverlayUtil.renderTextLocation(graphics, new Point((int) rectangle.getCenterX() - 50, font.getSize()), "Protect item prayer disabled!!!", Color.red);
+			}
 			graphics.setStroke(oldStroke);
 		}
 		return null;


### PR DESCRIPTION
Adds a config option to display only a thin red border instead of the thick red border with large text.

Accidentally misspelled WhaleWatchers in the title of the commit sorry.