### PR TITLE
discord-service: initialize discord service before starting plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -331,6 +331,9 @@ public class RuneLite
 		RuneLiteSplashScreen.stage(.80, "Initialize UI");
 		clientUI.init(this);
 
+		// Initialize Discord service
+		discordService.init();
+
 		if (!isOutdated)
 		{
 			// Initialize chat colors
@@ -356,8 +359,6 @@ public class RuneLite
 
 		// Start plugins
 		pluginManager.startCorePlugins();
-
-		discordService.init();
 
 		// Register additional schedulers
 		if (this.client != null)


### PR DESCRIPTION
fixes `Discord error: 4000 - child "pid" fails because ["pid" must be larger than or equal to 10]`
doesnt fix party plugin