### PR TITLE
slayermusiq: added the fremennik exiles link

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/QuestGuideLinks.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/slayermusiq/QuestGuideLinks.java
@@ -155,6 +155,7 @@ class QuestGuideLinks
 		new Link("The Slug Menace", "https://www.youtube.com/watch?v=BRQbdr3JEZ8"),
 		new Link("Another Slice of H.A.M.", "https://www.youtube.com/watch?v=Yq3db7827Lk"),
 		new Link("Song of the Elves", "https://www.youtube.com/watch?v=oMGvdBCuxoY"),
+		new Link("The Fremennik Exiles", "https://www.youtube.com/watch?v=1Vz2rXYhi4E"),
 		//Miniquests
 		new Link("Alfred Grimhand's Barcrawl", "https://www.youtube.com/watch?v=hE2dmiDaoK4"),
 		new Link("Bear your Soul", "https://www.youtube.com/watch?v=Pb6N-_6HJNc"),


### PR DESCRIPTION
This adds a working right click > slayermusiq option to the new Fremennik Exiles quest. Action will open up the quest guide on YT.