### PR TITLE
api: add devin's query system back in for niche uses.

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/Actor.java
+++ b/runelite-api/src/main/java/net/runelite/api/Actor.java
@@ -35,7 +35,7 @@ import net.runelite.api.coords.WorldPoint;
 /**
  * Represents a RuneScape actor/entity.
  */
-public interface Actor extends Entity
+public interface Actor extends Entity, Locatable
 {
 	/**
 	 * Gets the combat level of the actor.

--- a/runelite-api/src/main/java/net/runelite/api/Locatable.java
+++ b/runelite-api/src/main/java/net/runelite/api/Locatable.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, tha23rd <https://https://github.com/tha23rd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
+public interface Locatable
+{
+	/**
+	 * Gets the server-side location of the actor.
+	 * <p>
+	 * This value is typically ahead of where the client renders and is not
+	 * affected by things such as animations.
+	 *
+	 * @return the server location
+	 */
+	WorldPoint getWorldLocation();
+
+	/**
+	 * Gets the client-side location of the actor.
+	 *
+	 * @return the client location
+	 */
+	LocalPoint getLocalLocation();
+}

--- a/runelite-api/src/main/java/net/runelite/api/LocatableQueryResults.java
+++ b/runelite-api/src/main/java/net/runelite/api/LocatableQueryResults.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019, tha23rd <https://https://github.com/tha23rd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import java.util.Collection;
+import java.util.Comparator;
+import javax.annotation.Nullable;
+
+public class LocatableQueryResults<EntityType extends Locatable> extends QueryResults<EntityType>
+{
+
+	public LocatableQueryResults(Collection<? extends EntityType> results)
+	{
+		super(results);
+	}
+
+	@Nullable
+	public EntityType nearestTo(Locatable locatable)
+	{
+		return this.stream()
+				.min(Comparator.comparing(entityType -> entityType.getLocalLocation().distanceTo(locatable.getLocalLocation())))
+				.orElse(null);
+	}
+
+}

--- a/runelite-api/src/main/java/net/runelite/api/Query.java
+++ b/runelite-api/src/main/java/net/runelite/api/Query.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import java.util.function.Predicate;
+
+/**
+ * A query to search the game for objects that match.
+ *
+ * @param <EntityType> the returned object type
+ * @param <QueryType>  the query type
+ */
+public abstract class Query<EntityType, QueryType, QR extends QueryResults>
+{
+	protected Predicate<EntityType> predicate = x -> true;
+
+	protected Query()
+	{
+	}
+
+	/**
+	 * Executes the query and filters through possible objects, returning only
+	 * those who evaluate true using {@link #predicate}.
+	 *
+	 * @param client the game client
+	 * @return the matching objects
+	 */
+	public abstract QR result(Client client);
+
+	/**
+	 * Constructs and returns a predicate that will evaluate {@link #predicate}
+	 * and the passed value.
+	 *
+	 * @param other the passed predicate
+	 * @return the combined predicate
+	 */
+	protected Predicate<EntityType> and(Predicate<EntityType> other)
+	{
+		if (predicate == null)
+		{
+			return other;
+		}
+		return predicate.and(other);
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/QueryResults.java
+++ b/runelite-api/src/main/java/net/runelite/api/QueryResults.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2019, tha23rd <https://https://github.com/tha23rd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import javax.annotation.Nullable;
+
+public class QueryResults<EntityType> implements Collection<EntityType>
+{
+
+	public final ArrayList<EntityType> list;
+
+	public QueryResults(Collection<? extends EntityType> results)
+	{
+		if (results == null)
+		{
+			list = new ArrayList<>();
+		}
+		else
+		{
+			if (results instanceof ArrayList)
+			{
+				list = (ArrayList<EntityType>) results;
+			}
+			else
+			{
+				list = new ArrayList<>(results);
+			}
+		}
+
+	}
+
+	@Override
+	public int size()
+	{
+		return list.size();
+	}
+
+	@Override
+	public boolean isEmpty()
+	{
+		return this.size() == 0;
+	}
+
+	@Override
+	public boolean contains(Object o)
+	{
+		return list.contains(o);
+	}
+
+	@Override
+	public Iterator<EntityType> iterator()
+	{
+		return list.iterator();
+	}
+
+	@Override
+	public Object[] toArray()
+	{
+		return list.toArray();
+	}
+
+	@Override
+	public <entityType> entityType[] toArray(entityType[] a)
+	{
+		return (entityType[]) this.list.toArray();
+	}
+
+	@Override
+	public boolean add(EntityType entityType)
+	{
+		return list.add(entityType);
+	}
+
+	@Override
+	public boolean remove(Object o)
+	{
+		return list.remove(o);
+	}
+
+	@Override
+	public boolean containsAll(Collection<?> c)
+	{
+		return list.containsAll(c);
+	}
+
+	@Override
+	public boolean addAll(Collection<? extends EntityType> c)
+	{
+		return list.addAll(c);
+	}
+
+	@Override
+	public boolean removeAll(Collection<?> c)
+	{
+		return list.removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll(Collection<?> c)
+	{
+		return list.retainAll(c);
+	}
+
+	@Override
+	public void clear()
+	{
+		list.clear();
+	}
+
+	@Nullable
+	public final EntityType first()
+	{
+		return this.size() == 0 ? null : this.get(0);
+	}
+
+	@Nullable
+	public final EntityType last()
+	{
+		int size;
+		return (size = this.size()) == 0 ? null : this.get(size - 1);
+	}
+
+	public EntityType get(int index)
+	{
+		return list.get(index);
+	}
+
+	public final QueryResults limit(int entries)
+	{
+		return this.limit(0, entries);
+	}
+
+	public final QueryResults limit(int startIndex, int amount)
+	{
+		List<EntityType> limitedList = new ArrayList<>(amount);
+
+		for (int i = startIndex; i < this.size() && i - startIndex < amount; i++)
+		{
+			limitedList.add(this.get(i));
+		}
+
+		this.list.retainAll(limitedList);
+		return this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/TileObject.java
+++ b/runelite-api/src/main/java/net/runelite/api/TileObject.java
@@ -34,7 +34,7 @@ import javax.annotation.Nullable;
 /**
  * Represents an object that a tile holds.
  */
-public interface TileObject
+public interface TileObject extends Locatable
 {
 	/**
 	 * Gets the hashed value of this object.

--- a/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import net.runelite.api.Actor;
+import net.runelite.api.coords.WorldPoint;
+
+public abstract class ActorQuery<EntityType extends Actor, QueryType> extends LocatableQuery<EntityType, QueryType>
+{
+	@SuppressWarnings("unchecked")
+	public QueryType nameEquals(String... names)
+	{
+		predicate = and(actor ->
+		{
+			for (String name : names)
+			{
+				String actorName = actor.getName();
+				if (actorName != null && actorName.equals(name))
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType nameContains(String... names)
+	{
+		predicate = and(actor ->
+		{
+			for (String name : names)
+			{
+				String actorName = actor.getName();
+				if (actorName != null && actorName.contains(name))
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isLevel(int level)
+	{
+		predicate = and(actor -> actor.getCombatLevel() == level);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType animationEquals(int animation)
+	{
+		predicate = and(actor -> actor.getAnimation() == animation);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isInteractingWith(Actor actor)
+	{
+		predicate = and(a -> a.getInteracting().equals(actor));
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isWithinArea(WorldPoint from, int area)
+	{
+		predicate = and(a -> a.getWorldArea().distanceTo(from) <= area);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType hasNoHealthBar()
+	{
+		predicate = and(a -> a.getHealthRatio() == -1);
+		return (QueryType) this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/ActorQuery.java
@@ -24,6 +24,7 @@
  */
 package net.runelite.api.queries;
 
+import java.util.function.Predicate;
 import net.runelite.api.Actor;
 import net.runelite.api.coords.WorldPoint;
 
@@ -97,6 +98,13 @@ public abstract class ActorQuery<EntityType extends Actor, QueryType> extends Lo
 	public QueryType hasNoHealthBar()
 	{
 		predicate = and(a -> a.getHealthRatio() == -1);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType filter(Predicate<EntityType> other)
+	{
+		predicate = and(other);
 		return (QueryType) this;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/queries/BankItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/BankItemQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+
+public class BankItemQuery extends WidgetItemQuery
+{
+	private static final int ITEM_EMPTY = 6512;
+
+	@Override
+	public QueryResults<WidgetItem> result(Client client)
+	{
+		Collection<WidgetItem> widgetItems = getBankItems(client);
+		return new QueryResults<>(widgetItems.stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WidgetItem> getBankItems(Client client)
+	{
+		Collection<WidgetItem> widgetItems = new ArrayList<>();
+		Widget bank = client.getWidget(WidgetInfo.BANK_ITEM_CONTAINER);
+		if (bank != null && !bank.isHidden())
+		{
+			Widget[] children = bank.getDynamicChildren();
+			for (int i = 0; i < children.length; i++)
+			{
+				Widget child = children[i];
+				if (child.getItemId() == ITEM_EMPTY || child.isSelfHidden())
+				{
+					continue;
+				}
+				// set bounds to same size as default inventory
+				Rectangle bounds = child.getBounds();
+				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
+				// Index is set to 0 because the widget's index does not correlate to the order in the bank
+				widgetItems.add(new WidgetItem(child.getItemId(), child.getItemQuantity(), 0, bounds, child));
+			}
+		}
+		return widgetItems;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/DecorativeObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/DecorativeObjectQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.DecorativeObject;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Tile;
+
+public class DecorativeObjectQuery extends TileObjectQuery<DecorativeObject, DecorativeObjectQuery>
+{
+	@Override
+	public LocatableQueryResults<DecorativeObject> result(Client client)
+	{
+		return new LocatableQueryResults<>(getDecorativeObjects(client).stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.distinct()
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<DecorativeObject> getDecorativeObjects(Client client)
+	{
+		Collection<DecorativeObject> objects = new ArrayList<>();
+		for (Tile tile : getTiles(client))
+		{
+			objects.add(tile.getDecorativeObject());
+		}
+		return objects;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/DialogQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/DialogQuery.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2019, tha23rd <https://https://github.com/tha23rd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+
+public class DialogQuery extends WidgetItemQuery
+{
+
+	@Override
+	public QueryResults<WidgetItem> result(Client client)
+	{
+		Collection<WidgetItem> widgetItems = getDialogs(client);
+		return new QueryResults<>(widgetItems.stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WidgetItem> getDialogs(Client client)
+	{
+		boolean npcDialog = false;
+		Collection<WidgetItem> widgetItems = new ArrayList<>();
+		Widget dialog = client.getWidget(219, 1);
+		if (dialog == null || dialog.isHidden())
+		{
+			dialog = client.getWidget(WidgetInfo.DIALOG_NPC);
+			npcDialog = true;
+		}
+		if (dialog == null || dialog.isHidden())
+		{
+			dialog = client.getWidget(WidgetInfo.DIALOG_PLAYER);
+			npcDialog = true;
+		}
+
+		if (dialog != null && !dialog.isHidden())
+		{
+			Widget[] children = npcDialog ? dialog.getStaticChildren() : dialog.getDynamicChildren();
+			for (int i = 1; i < children.length; i++)
+			{
+				Widget child = children[i];
+				// set bounds to same size as default inventory
+				Rectangle bounds = child.getBounds();
+				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
+				widgetItems.add(new WidgetItem(child.getId(), child.getItemQuantity(), i - 1, bounds, child));
+			}
+		}
+		return widgetItems;
+	}
+
+	public WidgetItemQuery textContains(String... texts)
+	{
+		predicate = and(widgetItem ->
+		{
+			for (String text : texts)
+			{
+				if (widgetItem.getWidget() != null)
+				{
+					String widgetText = widgetItem.getWidget().getText();
+					if (widgetText != null && widgetText.contains(text))
+					{
+						return true;
+					}
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/EquipmentItemQuery.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+
+public class EquipmentItemQuery extends WidgetItemQuery
+{
+	private static final WidgetInfo[] ALL_EQUIPMENT_WIDGET_INFOS =
+		{
+			WidgetInfo.EQUIPMENT_HELMET,
+			WidgetInfo.EQUIPMENT_CAPE,
+			WidgetInfo.EQUIPMENT_AMULET,
+			WidgetInfo.EQUIPMENT_WEAPON,
+			WidgetInfo.EQUIPMENT_BODY,
+			WidgetInfo.EQUIPMENT_SHIELD,
+			WidgetInfo.EQUIPMENT_LEGS,
+			WidgetInfo.EQUIPMENT_GLOVES,
+			WidgetInfo.EQUIPMENT_BOOTS,
+			WidgetInfo.EQUIPMENT_RING,
+			WidgetInfo.EQUIPMENT_AMMO,
+		};
+
+	private final Collection<WidgetInfo> slots = new ArrayList<>();
+
+	public EquipmentItemQuery slotEquals(WidgetInfo... slotWidgetInfo)
+	{
+		slots.addAll(Arrays.asList(slotWidgetInfo));
+		return this;
+	}
+
+	@Override
+	public QueryResults<WidgetItem> result(Client client)
+	{
+		Collection<WidgetItem> widgetItems = getEquippedItems(client);
+		return new QueryResults<>(widgetItems.stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WidgetItem> getEquippedItems(Client client)
+	{
+		Collection<WidgetItem> widgetItems = new ArrayList<>();
+		Widget equipment = client.getWidget(WidgetInfo.EQUIPMENT);
+		if (equipment != null && !equipment.isHidden())
+		{
+			if (slots.isEmpty())
+			{
+				slots.addAll(Arrays.asList(ALL_EQUIPMENT_WIDGET_INFOS));
+			}
+			for (WidgetInfo slot : slots)
+			{
+				Widget parentWidget = client.getWidget(slot);
+				Widget itemWidget = parentWidget.getChild(1);
+				// Check if background icon is hidden. if hidden, item is equipped.
+				boolean equipped = parentWidget.getChild(2).isSelfHidden();
+				// set bounds to same size as default inventory
+				Rectangle bounds = itemWidget.getBounds();
+				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
+				// Index is set to 0 because there is no set in stone order of equipment slots
+				widgetItems.add(new WidgetItem(equipped ? itemWidget.getItemId() : -1, itemWidget.getItemQuantity(), 0, bounds, itemWidget));
+			}
+		}
+		return widgetItems;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/GameObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/GameObjectQuery.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.GameObject;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Tile;
+
+public class GameObjectQuery extends TileObjectQuery<GameObject, GameObjectQuery>
+{
+	@Override
+	public LocatableQueryResults<GameObject> result(Client client)
+	{
+		return new LocatableQueryResults<>(getGameObjects(client).stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.distinct()
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<GameObject> getGameObjects(Client client)
+	{
+		Collection<GameObject> objects = new ArrayList<>();
+		for (Tile tile : getTiles(client))
+		{
+			GameObject[] gameObjects = tile.getGameObjects();
+			if (gameObjects != null)
+			{
+				objects.addAll(Arrays.asList(gameObjects));
+			}
+		}
+		return objects;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/GroundObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/GroundObjectQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.GroundObject;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Tile;
+
+public class GroundObjectQuery extends TileObjectQuery<GroundObject, GroundObjectQuery>
+{
+	@Override
+	public LocatableQueryResults<GroundObject> result(Client client)
+	{
+		return new LocatableQueryResults<>(getGroundObjects(client).stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.distinct()
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<GroundObject> getGroundObjects(Client client)
+	{
+		Collection<GroundObject> objects = new ArrayList<>();
+		for (Tile tile : getTiles(client))
+		{
+			objects.add(tile.getGroundObject());
+		}
+		return objects;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/InventoryItemQuery.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016-2018, Adam <Adam@sigterm.info>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import net.runelite.api.Client;
+import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.Query;
+import net.runelite.api.QueryResults;
+
+@RequiredArgsConstructor
+public class InventoryItemQuery extends Query<Item, InventoryItemQuery, QueryResults<Item>>
+{
+	private final InventoryID inventory;
+
+	@Override
+	public QueryResults<Item> result(Client client)
+	{
+		ItemContainer container = client.getItemContainer(inventory);
+		if (container == null)
+		{
+			return new QueryResults<>(null);
+		}
+		return new QueryResults<>(Arrays.stream(container.getItems())
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	public InventoryItemQuery idEquals(int... ids)
+	{
+		predicate = and(item ->
+		{
+			for (int id : ids)
+			{
+				if (item.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/InventoryWidgetItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/InventoryWidgetItemQuery.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+
+public class InventoryWidgetItemQuery extends WidgetItemQuery
+{
+	private static final WidgetInfo[] INVENTORY_WIDGET_INFOS =
+		{
+			WidgetInfo.DEPOSIT_BOX_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.BANK_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.SHOP_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.GRAND_EXCHANGE_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.GUIDE_PRICES_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.EQUIPMENT_INVENTORY_ITEMS_CONTAINER,
+			WidgetInfo.INVENTORY
+		};
+
+	@Override
+	public QueryResults<WidgetItem> result(Client client)
+	{
+		Collection<WidgetItem> widgetItems = getInventoryItems(client);
+		return new QueryResults<>(widgetItems.stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WidgetItem> getInventoryItems(Client client)
+	{
+		Collection<WidgetItem> widgetItems = new ArrayList<>();
+		for (WidgetInfo widgetInfo : INVENTORY_WIDGET_INFOS)
+		{
+			Widget inventory = client.getWidget(widgetInfo);
+			if (inventory == null || inventory.isHidden())
+			{
+				continue;
+			}
+			if (widgetInfo == WidgetInfo.INVENTORY)
+			{
+				widgetItems.addAll(inventory.getWidgetItems());
+				break;
+			}
+			else
+			{
+				Widget[] children = inventory.getDynamicChildren();
+				for (int i = 0; i < children.length; i++)
+				{
+					Widget child = children[i];
+					// set bounds to same size as default inventory
+					Rectangle bounds = child.getBounds();
+					bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
+					widgetItems.add(new WidgetItem(child.getItemId(), child.getItemQuantity(), i, bounds, child));
+				}
+				break;
+			}
+		}
+		return widgetItems;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/LocatableQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/LocatableQuery.java
@@ -25,6 +25,7 @@
 package net.runelite.api.queries;
 
 import static java.lang.Math.abs;
+import java.util.function.Predicate;
 import net.runelite.api.Locatable;
 import net.runelite.api.LocatableQueryResults;
 import net.runelite.api.Query;
@@ -70,6 +71,13 @@ public abstract class LocatableQuery<EntityType extends Locatable, QueryType> ex
 			return abs(localLocation.getX() - from.getX()) < area
 					&& abs(localLocation.getY() - from.getY()) < area;
 		});
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType filter(Predicate<EntityType> other)
+	{
+		predicate = and(other);
 		return (QueryType) this;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/queries/LocatableQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/LocatableQuery.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2019, tha23rd <https://https://github.com/tha23rd>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import static java.lang.Math.abs;
+import net.runelite.api.Locatable;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Query;
+import net.runelite.api.coords.LocalPoint;
+import net.runelite.api.coords.WorldPoint;
+
+public abstract class LocatableQuery<EntityType extends Locatable, QueryType> extends Query<EntityType, QueryType, LocatableQueryResults<EntityType>>
+{
+	@SuppressWarnings("unchecked")
+	public QueryType atWorldLocation(WorldPoint location)
+	{
+		predicate = and(object -> object.getWorldLocation().equals(location));
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType atLocalLocation(LocalPoint location)
+	{
+		predicate = and(object -> object.getLocalLocation().equals(location));
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isWithinDistance(LocalPoint to, int distance)
+	{
+		predicate = and(a -> a.getLocalLocation().distanceTo(to) <= distance);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isWithinDistance(WorldPoint to, int distance)
+	{
+		predicate = and(a -> a.getWorldLocation().distanceTo(to) <= distance);
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType isWithinArea(LocalPoint from, int area)
+	{
+		predicate = and(a ->
+		{
+			LocalPoint localLocation = a.getLocalLocation();
+			return abs(localLocation.getX() - from.getX()) < area
+					&& abs(localLocation.getY() - from.getY()) < area;
+		});
+		return (QueryType) this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/NPCQuery.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.NPC;
+
+public class NPCQuery extends ActorQuery<NPC, NPCQuery>
+{
+	@Override
+	public LocatableQueryResults<NPC> result(Client client)
+	{
+		return new LocatableQueryResults<>(client.getNpcs().stream()
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	@SuppressWarnings("unchecked")
+	public NPCQuery idEquals(int... ids)
+	{
+		predicate = and(object ->
+		{
+			for (int id : ids)
+			{
+				if (object.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public NPCQuery idEquals(Collection<Integer> ids)
+	{
+		predicate = and((object) -> ids.contains(object.getId()));
+		return this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/PlayerQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/PlayerQuery.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Player;
+
+public class PlayerQuery extends ActorQuery<Player, PlayerQuery>
+{
+	@Override
+	public LocatableQueryResults<Player> result(Client client)
+	{
+		Collection<Player> players = client.getPlayers();
+		return new LocatableQueryResults<>(players.stream()
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/ShopItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/ShopItemQuery.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.awt.Rectangle;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetItem;
+
+public class ShopItemQuery extends WidgetItemQuery
+{
+	@Override
+	public QueryResults<WidgetItem> result(Client client)
+	{
+		Collection<WidgetItem> widgetItems = getShopItems(client);
+		return new QueryResults<>(widgetItems.stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WidgetItem> getShopItems(Client client)
+	{
+		Collection<WidgetItem> widgetItems = new ArrayList<>();
+		Widget shop = client.getWidget(WidgetInfo.SHOP_ITEMS_CONTAINER);
+		if (shop != null && !shop.isHidden())
+		{
+			Widget[] children = shop.getDynamicChildren();
+			for (int i = 1; i < children.length; i++)
+			{
+				Widget child = children[i];
+				// set bounds to same size as default inventory
+				Rectangle bounds = child.getBounds();
+				bounds.setBounds(bounds.x - 1, bounds.y - 1, 32, 32);
+				widgetItems.add(new WidgetItem(child.getItemId(), child.getItemQuantity(), i - 1, bounds, child));
+			}
+		}
+		return widgetItems;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
@@ -27,6 +27,7 @@ package net.runelite.api.queries;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import net.runelite.api.Client;
 import net.runelite.api.Constants;
 import net.runelite.api.Scene;
@@ -78,6 +79,13 @@ public abstract class TileObjectQuery<EntityType extends TileObject, QueryType> 
 	public QueryType idEquals(Collection<Integer> ids)
 	{
 		predicate = and((object) -> ids.contains(object.getId()));
+		return (QueryType) this;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType filter(Predicate<EntityType> other)
+	{
+		predicate = and(other);
 		return (QueryType) this;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/TileObjectQuery.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import net.runelite.api.Client;
+import net.runelite.api.Constants;
+import net.runelite.api.Scene;
+import net.runelite.api.Tile;
+import net.runelite.api.TileObject;
+
+public abstract class TileObjectQuery<EntityType extends TileObject, QueryType> extends LocatableQuery<EntityType, QueryType>
+{
+	protected List<Tile> getTiles(Client client)
+	{
+		List<Tile> tilesList = new ArrayList<>();
+		Scene scene = client.getScene();
+		Tile[][][] tiles = scene.getTiles();
+		int z = client.getPlane();
+		for (int x = 0; x < Constants.SCENE_SIZE; ++x)
+		{
+			for (int y = 0; y < Constants.SCENE_SIZE; ++y)
+			{
+				Tile tile = tiles[z][x][y];
+				if (tile == null)
+				{
+					continue;
+				}
+				tilesList.add(tile);
+			}
+		}
+		return tilesList;
+	}
+
+	@SuppressWarnings("unchecked")
+	public QueryType idEquals(int... ids)
+	{
+		predicate = and(object ->
+		{
+			for (int id : ids)
+			{
+				if (object.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return (QueryType) this;
+	}
+
+
+	@SuppressWarnings("unchecked")
+	public QueryType idEquals(Collection<Integer> ids)
+	{
+		predicate = and((object) -> ids.contains(object.getId()));
+		return (QueryType) this;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/WallObjectQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/WallObjectQuery.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import net.runelite.api.Client;
+import net.runelite.api.LocatableQueryResults;
+import net.runelite.api.Tile;
+import net.runelite.api.WallObject;
+
+public class WallObjectQuery extends TileObjectQuery<WallObject, WallObjectQuery>
+{
+	@Override
+	public LocatableQueryResults<WallObject> result(Client client)
+	{
+		return new LocatableQueryResults<>(getWallObjects(client).stream()
+			.filter(Objects::nonNull)
+			.filter(predicate)
+			.distinct()
+			.collect(Collectors.toList()));
+	}
+
+	private Collection<WallObject> getWallObjects(Client client)
+	{
+		Collection<WallObject> objects = new ArrayList<>();
+		for (Tile tile : getTiles(client))
+		{
+			objects.add(tile.getWallObject());
+		}
+		return objects;
+	}
+}

--- a/runelite-api/src/main/java/net/runelite/api/queries/WidgetItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/WidgetItemQuery.java
@@ -25,6 +25,7 @@
 package net.runelite.api.queries;
 
 import java.util.Collection;
+import java.util.function.Predicate;
 import net.runelite.api.Query;
 import net.runelite.api.QueryResults;
 import net.runelite.api.widgets.WidgetItem;
@@ -72,6 +73,12 @@ public abstract class WidgetItemQuery extends Query<WidgetItem, WidgetItemQuery,
 	public WidgetItemQuery quantityEquals(int quantity)
 	{
 		predicate = and(item -> item.getQuantity() == quantity);
+		return this;
+	}
+
+	public WidgetItemQuery filter(Predicate<WidgetItem> other)
+	{
+		predicate = and(other);
 		return this;
 	}
 }

--- a/runelite-api/src/main/java/net/runelite/api/queries/WidgetItemQuery.java
+++ b/runelite-api/src/main/java/net/runelite/api/queries/WidgetItemQuery.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, Devin French <https://github.com/devinfrench>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package net.runelite.api.queries;
+
+import java.util.Collection;
+import net.runelite.api.Query;
+import net.runelite.api.QueryResults;
+import net.runelite.api.widgets.WidgetItem;
+
+public abstract class WidgetItemQuery extends Query<WidgetItem, WidgetItemQuery, QueryResults<WidgetItem>>
+{
+	public WidgetItemQuery idEquals(int... ids)
+	{
+		predicate = and(item ->
+		{
+			for (int id : ids)
+			{
+				if (item.getId() == id)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	public WidgetItemQuery idEquals(Collection<Integer> ids)
+	{
+		predicate = and((object) -> ids.contains(object.getId()));
+		return this;
+	}
+
+	public WidgetItemQuery indexEquals(int... indexes)
+	{
+		predicate = and(item ->
+		{
+			for (int index : indexes)
+			{
+				if (item.getIndex() == index)
+				{
+					return true;
+				}
+			}
+			return false;
+		});
+		return this;
+	}
+
+	public WidgetItemQuery quantityEquals(int quantity)
+	{
+		predicate = and(item -> item.getQuantity() == quantity);
+		return this;
+	}
+}


### PR DESCRIPTION
An Implementation of Devin French's query system, expanded upon a bit.

This PR allows for querying of various entities in Runelite such as:

- NPCs
- Game Objects
- Dialog
- Equipment
- Inventory Items
- Players
- Shop Items
- And more

Example Query:
`new NPCQuery().nameContains("Fishing spot").result(client).nearestTo(client.getLocalPlayer());`

This is meant to be a foundation for a framework, as new commonly methods are thought up, they can be added to the various `QueryResult` classes.

To be improved:
Caching should probably be implemented at some point
Dialog querying only supports a limited selection of dialog types, this can be expanded upon