### PR TITLE
coxhelper: fix teleport timers for names with spaces

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/coxhelper/CoxPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/coxhelper/CoxPlugin.java
@@ -217,9 +217,16 @@ public class CoxPlugin extends Plugin
 			{
 				for (Player player : client.getPlayers())
 				{
-					if (player.getName().equals(tpMatcher.group(1)))
+					final String rawPlayerName = player.getName();
+
+					if (rawPlayerName != null)
 					{
-						victims.add(new Victim(player, Victim.Type.TELEPORT));
+						final String fixedPlayerName = Text.sanitize(rawPlayerName);
+
+						if (fixedPlayerName.equals(tpMatcher.group(1)))
+						{
+							victims.add(new Victim(player, Victim.Type.TELEPORT));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
sanitize player name for non-breaking spaces
add null check player name

closes #1626 